### PR TITLE
(refactor)Replace usages of /ws/rest/v1 with restBaseUrl

### DIFF
--- a/src/stock-home/useStockList.tsx
+++ b/src/stock-home/useStockList.tsx
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 
 interface StockList {
   uuid: string;
@@ -13,7 +13,7 @@ interface StockList {
 }
 
 const useStockList = () => {
-  const url = `/ws/rest/v1/stockmanagement/stockitem`;
+  const url = `${restBaseUrl}/stockmanagement/stockitem`;
 
   const { data, error } = useSWR<{ data: { results: Array<StockList> } }>(
     url,

--- a/src/stock-items/add-bulk-stock-item/stock-items-bulk-import.resource.ts
+++ b/src/stock-items/add-bulk-stock-item/stock-items-bulk-import.resource.ts
@@ -1,9 +1,9 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 
 export async function UploadStockItems(body: any) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/stockmanagement/stockitemimport`, {
+  return openmrsFetch(`${restBaseUrl}/stockmanagement/stockitemimport`, {
     method: "POST",
     // headers: {
     //   "Content-Type": "application/json",

--- a/src/stock-lookups/stock-lookups.resource.ts
+++ b/src/stock-lookups/stock-lookups.resource.ts
@@ -4,6 +4,7 @@ import {
   fhirBaseUrl,
   openmrsFetch,
   useSession,
+  restBaseUrl,
 } from "@openmrs/esm-framework";
 import { ResourceFilterCriteria, toQueryParams } from "../core/api/api";
 import { PageableResult } from "../core/api/types/PageableResult";
@@ -289,7 +290,7 @@ type UserRole = {
 
 export const useUserRoles = () => {
   const { user: loggedInUser } = useSession();
-  const url = `/ws/rest/v1/stockmanagement/userrolescope`;
+  const url = `${restBaseUrl}/stockmanagement/userrolescope`;
   const { data, isLoading, error } = useSWR<{ data: UserRole }>(
     url,
     openmrsFetch


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the restBaseUrl variable instead. To enhances maintainability and flexibility of the API base URL configuration.

## Screenshots
N/A

## Related Issue
https://openmrs.atlassian.net/browse/O3-2815

## Other
<!-- Anything not covered above -->
<!-- *None* -->
