### PR TITLE
Stock management: user roles aren't showing all users in the event

### DIFF
--- a/src/stock-lookups/stock-lookups.resource.ts
+++ b/src/stock-lookups/stock-lookups.resource.ts
@@ -178,7 +178,7 @@ export function useUsers(filter: UserFilterCriteria) {
 
 // getUser
 export function useUser(id: string) {
-  const apiUrl = `${restBaseUrl}/user${id}`;
+  const apiUrl = `${restBaseUrl}/user/${id}`;
   const { data, error, isLoading } = useSWR<
     {
       data: User;

--- a/src/stock-user-role-scopes/add-stock-user-scope/add-stock-user-role-scope.component.tsx
+++ b/src/stock-user-role-scopes/add-stock-user-scope/add-stock-user-role-scope.component.tsx
@@ -14,10 +14,9 @@ import {
   Select,
   SelectItem,
 } from "@carbon/react";
-import React, { ChangeEvent, useMemo, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import styles from "./add-stock-user-role-scope.scss";
 import {
-  UserFilterCriteria,
   useRoles,
   useStockOperationTypes,
   useStockTagLocations,
@@ -64,7 +63,6 @@ const AddStockUserRoleScope: React.FC<AddStockUserRoleScopeProps> = ({
 
   const [roles, setRoles] = useState<Role[]>([]);
 
-  const { data: user } = useUser(model?.uuid);
   const [showItems, setShowItems] = useState(false);
 
   // operation types
@@ -79,6 +77,9 @@ const AddStockUserRoleScope: React.FC<AddStockUserRoleScopeProps> = ({
 
     isLoading: loadingUsers,
   } = useUsers({ v: ResourceRepresentation.Default });
+
+  const [selectedUserUuid, setSelectedUserUuid] = useState<string | null>(null);
+  const { data: user, isError } = useUser(selectedUserUuid);
 
   // get roles
   const { items: rolesData, isLoading: loadingRoles } = useRoles({
@@ -201,17 +202,6 @@ const AddStockUserRoleScope: React.FC<AddStockUserRoleScopeProps> = ({
   const onActiveDatesChange = (dates: Date[]): void => {
     setFormModel({ ...formModel, activeFrom: dates[0], activeTo: dates[1] });
   };
-  const handleUsersSearch = useMemo(
-    () =>
-      debounce((searchTerm) => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        useUsers({
-          v: ResourceRepresentation.Default,
-          q: searchTerm,
-        } as any as UserFilterCriteria);
-      }, 3),
-    []
-  );
 
   const onUserChanged = (data: { selectedItem: User }) => {
     const stockRolesUUIDs = [
@@ -227,8 +217,7 @@ const AddStockUserRoleScope: React.FC<AddStockUserRoleScopeProps> = ({
     );
     setFormModel({ ...formModel, userUuid: data.selectedItem?.uuid });
     setRoles(filteredStockRoles ?? []);
-
-    console.info(roles);
+    setSelectedUserUuid(data?.selectedItem?.uuid);
   };
 
   const onRoleChange = (e: ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Stock management: user roles aren't showing all users in the event users are more the default rest page size.

## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->
The submission cannot work as the user selected is undefined. This is the error on submission and on select
![stockError](https://github.com/openmrs/openmrs-esm-stock-management/assets/8075969/d46e80d2-4722-4a74-9048-a9fbde5ae5b4)

The error was fixed and this is the new look.
![stockManageement](https://github.com/openmrs/openmrs-esm-stock-management/assets/8075969/b01d8de8-9616-4ea1-a0e5-593cd984a426)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
