### PR TITLE
(fix) O3-3399 Packing Units Quantity field shouldn't allow user to input negative number of stock items 

### DIFF
--- a/src/core/components/carbon/controlled-number-input/controlled-number-input.component.tsx
+++ b/src/core/components/carbon/controlled-number-input/controlled-number-input.component.tsx
@@ -20,6 +20,7 @@ const ControlledNumberInput = <T,>(props: ControlledNumberInputProps<T>) => {
         <NumberInput
           id={`${props.name}-${props.row?.id}-${props.row?.uuid}`}
           value={props.row?.factor ?? value}
+          min={props.min}
           ref={ref}
           onChange={(
             event: React.MouseEvent<HTMLButtonElement>,

--- a/src/stock-items/add-stock-item/packaging-units/packaging-units.component.tsx
+++ b/src/stock-items/add-stock-item/packaging-units/packaging-units.component.tsx
@@ -174,6 +174,7 @@ const PackagingUnitRow: React.FC<{
     control,
     formState: { errors },
   } = useFormContext();
+  const minPackagingQuantity = 0;
 
   return (
     <>
@@ -198,6 +199,7 @@ const PackagingUnitRow: React.FC<{
               row={row}
               controllerName="factor"
               name="factor"
+              min={minPackagingQuantity}
               control={control}
               id={`${row.uuid}-${key}`}
               invalid={!!errors.factor}

--- a/src/stock-items/add-stock-item/stock-item-details/stock-item-details.component.tsx
+++ b/src/stock-items/add-stock-item/stock-item-details/stock-item-details.component.tsx
@@ -172,6 +172,7 @@ const StockItemDetails = forwardRef<never, StockItemDetailsProps>(
                 name="expiryNotice"
                 control={control}
                 controllerName="expiryNotice"
+                min={0}
                 size={"md"}
                 allowEmpty={true}
                 label={t("expiryNoticeDays", "Expiration Notice (days)")}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR locks the packaging unit quantity field so that it doesn't allow a user to input a negative quantity. It also locks the Expiration Notice Field to do the same.

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
