### PR TITLE
(fix) O3-3666: The stock item dropdown should display depending on what was checked above i.e drugs or non drug

### DIFF
--- a/src/stock-items/add-stock-item/stock-item-category-selector/stock-item-category-selector.component.tsx
+++ b/src/stock-items/add-stock-item/stock-item-category-selector/stock-item-category-selector.component.tsx
@@ -14,6 +14,7 @@ interface StockItemCategorySelectorProps<T> {
   placeholder?: string;
   invalid?: boolean;
   invalidText?: ReactNode;
+  itemType?: string;
 
   // Control
   controllerName: string;
@@ -32,6 +33,10 @@ const StockItemCategorySelector = <T,>(
     isLoading,
   } = useConcept(stockItemCategoryUUID);
 
+  const filteredCategories = props.itemType
+    ? categories?.filter((c) => c.display === props?.itemType)
+    : categories;
+
   if (isLoading) return <TextInputSkeleton />;
 
   return (
@@ -46,7 +51,7 @@ const StockItemCategorySelector = <T,>(
           controllerName={props.controllerName}
           id={props.name}
           size={"md"}
-          items={categories || []}
+          items={filteredCategories || []}
           onChange={(data: { selectedItem: Concept }) => {
             props.onCategoryUuidChange?.(data.selectedItem);
             onChange(data.selectedItem?.uuid);

--- a/src/stock-items/add-stock-item/stock-item-details/stock-item-details.component.tsx
+++ b/src/stock-items/add-stock-item/stock-item-details/stock-item-details.component.tsx
@@ -61,10 +61,18 @@ const StockItemDetails = forwardRef<never, StockItemDetailsProps>(
 
     const [isSaving, setIsSaving] = useState(false);
     const [isDrug, setIsDrug] = useState(false);
+    const [selectedItemType, setSelectedItemType] = useState("");
     const [hasExpiration, setHasExpiration] = useState(false);
 
     useEffect(() => {
       setIsDrug(model.isDrug ?? false);
+      setSelectedItemType(
+        model.isDrug === true
+          ? "Pharmaceuticals"
+          : model.isDrug === false
+          ? "Non Pharmaceuticals"
+          : undefined
+      );
       setHasExpiration(model.hasExpiration ?? false);
     }, [model.hasExpiration, model.isDrug]);
 
@@ -85,7 +93,12 @@ const StockItemDetails = forwardRef<never, StockItemDetailsProps>(
             invalid={!!errors.isDrug}
             invalidText={errors.isDrug && errors?.isDrug?.message}
             onChange={(selection: boolean) => {
+              const selectedOption = radioOptions.find(
+                (option) => option.value === selection
+              );
+              const selectedLabel = selectedOption ? selectedOption.label : "";
               setIsDrug(selection);
+              setSelectedItemType(selectedLabel);
             }}
             options={radioOptions} // Pass radioOptions directly
           />
@@ -201,6 +214,13 @@ const StockItemDetails = forwardRef<never, StockItemDetailsProps>(
           name="categoryUuid"
           controllerName="categoryUuid"
           control={control}
+          itemType={
+            selectedItemType === "Pharmaceuticals"
+              ? "Drugs"
+              : selectedItemType === "Non Pharmaceuticals"
+              ? "Non Drugs"
+              : undefined
+          }
           title={t("category:", "Category") + ":"}
           placeholder={t("chooseACategory", "Choose a category")}
           invalid={!!errors.categoryUuid}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Introduces a new state to capture the label for the selected item since it is using booleans, so when non is selected the label is undefined and both options appear, then if a specific type is selected, the list gets filtered accordingly.

## Screenshots

https://github.com/user-attachments/assets/430df14e-83d7-4a88-8729-eab11e45eab1


## Related Issue
- https://openmrs.atlassian.net/browse/O3-3666

