### PR TITLE
(fix) O3-3670: Refresh/mutate the stock item after creating/editing a packaging unit

### DIFF
--- a/src/stock-items/add-stock-item/packaging-units/packaging-units.component.tsx
+++ b/src/stock-items/add-stock-item/packaging-units/packaging-units.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { showSnackbar } from "@openmrs/esm-framework";
+import { showSnackbar, restBaseUrl } from "@openmrs/esm-framework";
 import { useTranslation } from "react-i18next";
 import { useStockItemPackageUnitsHook } from "./packaging-units.resource";
 import {
@@ -26,6 +26,7 @@ import {
   updateStockItemPackagingUnit,
 } from "../../stock-items.resource";
 import DeleteModalButton from "./packaging-units-delete-modal-button.component";
+import { handleMutate } from "../../../utils";
 
 import styles from "./packaging-units.scss";
 
@@ -171,6 +172,7 @@ const PackagingUnits: React.FC<PackagingUnitsProps> = ({
     // Wait for all requests to complete
     Promise.all([createPromises, ...updatePromises]).then(() => {
       mutate();
+      handleMutate(`${restBaseUrl}/stockmanagement/stockitem`);
       reset();
       handleTabChange(0);
     });

--- a/src/stock-items/stock-item.utils.tsx
+++ b/src/stock-items/stock-item.utils.tsx
@@ -52,7 +52,9 @@ export const launchAddOrEditDialog = (
   isEditing = false
 ) => {
   launchOverlay(
-    `${isEditing ? "Edit" : "Add"} ${stockItem?.drugName || ""}`,
+    `${isEditing ? "Edit" : "Add"} ${
+      stockItem?.drugName || stockItem.conceptName || ""
+    }`,
     <AddEditStockItem
       model={stockItem}
       onSave={(stockItem) => addOrEditStockItem(stockItem, isEditing)}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Mutate/ refetch the stock item after creating or editing packaging units
- Also added a fix for displaying non drug name in edit mode

## Screenshots

https://github.com/user-attachments/assets/ef3f0d5b-fe02-4e54-80a9-34056f1d27ae

<img width="1404" alt="Screenshot 2024-07-29 at 16 24 40" src="https://github.com/user-attachments/assets/85e158d0-81f6-4226-9877-fe2314794cb2">


## Related Issue
- https://openmrs.atlassian.net/browse/O3-3670
- https://openmrs.atlassian.net/browse/O3-3668
## Other
<!-- Anything not covered above -->
<!-- *None* -->
