### PR TITLE
O3-3695-Show received stock items list after a stock issue operations has been disp

### DIFF
--- a/src/core/api/types/stockOperation/StockOperationDTO.ts
+++ b/src/core/api/types/stockOperation/StockOperationDTO.ts
@@ -3,6 +3,7 @@ import { StockOperationItemDTO } from "./StockOperationItemDTO";
 import { StockOperationStatus } from "./StockOperationStatus";
 
 export interface StockOperationDTO {
+  receivedItems: any;
   uuid: string | null | undefined;
   cancelReason: string | null | undefined;
   cancelledBy: number;

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -61,6 +61,8 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
   }
 
   let operations: StockOperationType[] | null | undefined;
+  const status = props?.model?.status;
+
   const tabs: TabItem[] = [
     {
       name: isEditing
@@ -82,7 +84,7 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
               : props?.operation?.name === "Stock Issue"
               ? props?.model
               : result?.dto
-          } // check if type is stockIssue and pass requistion data
+          } // check if type is stockIssue and pass requisition data
           onSave={async () => {
             setManageStockItems(true);
             setSelectedIndex(1);
@@ -105,7 +107,7 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
               : props?.operation?.name === "Stock Issue"
               ? props?.model
               : result?.dto
-          } // check if type is stockIssue and pass requistion data
+          } // check if type is stockIssue and pass requisition data
           onSave={async () => {
             setManageSubmitOrComplete(true);
             setSelectedIndex(2);
@@ -172,14 +174,17 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
     StockOperationTypeIsStockIssue(
       props?.model?.operationType as OperationType
     ) || canReceiveItems
-      ? [
-          {
-            name: t("receivedItems", "Received Items"),
-            component: <ReceivedItems model={props?.model} />,
-          },
-        ]
+      ? status === "DISPATCHED" || status === "COMPLETED"
+        ? [
+            {
+              name: t("receivedItems", "Received Items"),
+              component: <ReceivedItems model={props?.model} />,
+            },
+          ]
+        : []
       : []
   );
+
   return (
     <>
       {!isEditing && props.operation.name === "Stock Issue" ? (

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -26,6 +26,7 @@ import { StockOperation } from "./stock-operation-context/useStockOperationConte
 import { formatDate, parseDate, showSnackbar } from "@openmrs/esm-framework";
 import {
   OperationType,
+  StockOperationTypeIsStockIssue,
   StockOperationType,
 } from "../../core/api/types/stockOperation/StockOperationType";
 import { operationStatusColor } from "../stock-operations.resource";
@@ -162,11 +163,16 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
       ),
       disabled: !(props.isEditing || manageSubmitOrComplete),
     },
-    {
-      name: t("receivedItems", "Received Items"),
-      component: <ReceivedItems model={props?.model} />,
-    },
-  ];
+  ].concat(
+    StockOperationTypeIsStockIssue(props?.model?.operationType as OperationType)
+      ? [
+          {
+            name: t("receivedItems", "Received Items"),
+            component: <ReceivedItems model={props?.model} />,
+          },
+        ]
+      : []
+  );
 
   return (
     <>

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -5,6 +5,7 @@ import VerticalTabs from "../../core/components/tabs/vertical-tabs.component";
 import BaseOperationDetails from "./base-operation-details.component";
 import StockItemsAddition from "./stock-items-addition.component";
 import StockOperationSubmission from "./stock-operation-submission.component";
+import ReceivedItems from "./received-items.component";
 import { AddStockOperationProps } from "./types";
 import { useInitializeStockOperations } from "./add-stock-operation.resource";
 import { AccordionSkeleton } from "@carbon/react";
@@ -160,6 +161,10 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
         />
       ),
       disabled: !(props.isEditing || manageSubmitOrComplete),
+    },
+    {
+      name: t("receivedItems", "Received Items"),
+      component: <ReceivedItems model={props?.model} />,
     },
   ];
 

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -171,7 +171,7 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
   ].concat(
     StockOperationTypeIsStockIssue(
       props?.model?.operationType as OperationType
-    ) && canReceiveItems
+    ) || canReceiveItems
       ? [
           {
             name: t("receivedItems", "Received Items"),

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TabItem } from "../../core/components/tabs/types";
 import VerticalTabs from "../../core/components/tabs/vertical-tabs.component";
@@ -41,6 +41,11 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
     props?.isEditing
   );
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [canReceiveItems, setCanReceiveItems] = useState(false);
+
+  useEffect(() => {
+    setCanReceiveItems(props?.model?.permission?.canReceiveItems ?? false);
+  }, [props?.model?.permission]);
 
   if (isLoading) return <AccordionSkeleton />;
   if (isError) {
@@ -164,7 +169,9 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
       disabled: !(props.isEditing || manageSubmitOrComplete),
     },
   ].concat(
-    StockOperationTypeIsStockIssue(props?.model?.operationType as OperationType)
+    StockOperationTypeIsStockIssue(
+      props?.model?.operationType as OperationType
+    ) && canReceiveItems
       ? [
           {
             name: t("receivedItems", "Received Items"),
@@ -173,7 +180,6 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
         ]
       : []
   );
-
   return (
     <>
       {!isEditing && props.operation.name === "Stock Issue" ? (

--- a/src/stock-operations/add-stock-operation/add-stock-operation.utils.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.utils.tsx
@@ -70,7 +70,10 @@ export async function initializeNewStockOperation(
   let destinationPartyList: Party[] | null | undefined;
 
   if (isNew) {
-    model = structuredClone(initialStockOperationValue());
+    model = structuredClone({
+      ...initialStockOperationValue(),
+      receivedItems: [],
+    });
     model = Object.assign(model, {
       operationDate: today(),
       operationTypeName: currentStockOperationType?.name,

--- a/src/stock-operations/add-stock-operation/received-items.component.tsx
+++ b/src/stock-operations/add-stock-operation/received-items.component.tsx
@@ -14,7 +14,7 @@ import {
 } from "@carbon/react";
 
 const formatDate = (date: Date | string | null) => {
-  if (!date) return "N/A";
+  if (!date) return " ";
   const d = new Date(date);
   const day = String(d.getDate()).padStart(2, "0");
   const month = String(d.getMonth() + 1).padStart(2, "0");
@@ -39,22 +39,15 @@ const ReceivedItems: React.FC<ReceivedItemsProps> = ({ model }) => {
     { key: "qtyUoM", header: t("qtyUoM", "Qty UoM") },
   ];
 
-  // Check if the model status is either DISPATCHED or COMPLETED
-  if (model?.status !== "DISPATCHED" && model?.status !== "COMPLETED") {
-    return (
-      <div>{t("statusNotValid", "No items to display for this status.")}</div>
-    );
-  }
-
   const rows =
-    model?.stockOperationItems?.map((item, index) => ({
+    model?.stockOperationItems?.map((item) => ({
       id: item.uuid,
       item: item.stockItemName,
-      requested: item.quantityRequested || "N/A",
+      requested: item.quantityRequested || " ",
       batch: item.batchNo,
       expiry: formatDate(item.expiration),
-      qtySent: item.quantity || "N/A",
-      qtyReceived: item.quantityReceived || "N/A",
+      qtySent: item.quantity || " ",
+      qtyReceived: item.quantityReceived || " ",
       qtyUoM: item.quantityReceivedPackagingUOMName,
     })) || [];
 

--- a/src/stock-operations/add-stock-operation/received-items.component.tsx
+++ b/src/stock-operations/add-stock-operation/received-items.component.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { StockOperationDTO } from "../../core/api/types/stockOperation/StockOperationDTO";
+import {
+  DataTable,
+  Table,
+  TableBody,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCell,
+  DataTableSkeleton,
+} from "@carbon/react";
+
+const formatDate = (date: Date | string | null) => {
+  if (!date) return "N/A";
+  const d = new Date(date);
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const year = d.getFullYear();
+  return `${month}/${day}/${year}`;
+};
+
+interface ReceivedItemsProps {
+  model?: StockOperationDTO;
+}
+
+const ReceivedItems: React.FC<ReceivedItemsProps> = ({ model }) => {
+  const { t } = useTranslation();
+
+  const headers = [
+    { key: "item", header: t("item", "Item") },
+    { key: "requested", header: t("requested", "Requested") },
+    { key: "batch", header: t("batch", "Batch No") },
+    { key: "expiry", header: t("expiry", "Expiry Date") },
+    { key: "qtySent", header: t("qtySent", "Qty Sent") },
+    { key: "qtyReceived", header: t("qtyReceived", "Qty Received") },
+    { key: "qtyUoM", header: t("qtyUoM", "Qty UoM") },
+  ];
+
+  // Check if the model status is either DISPATCHED or COMPLETED
+  if (model?.status !== "DISPATCHED" && model?.status !== "COMPLETED") {
+    return (
+      <div>{t("statusNotValid", "No items to display for this status.")}</div>
+    );
+  }
+
+  const rows =
+    model?.stockOperationItems?.map((item, index) => ({
+      id: item.uuid,
+      item: item.stockItemName,
+      requested: item.quantityRequested || "N/A",
+      batch: item.batchNo,
+      expiry: formatDate(item.expiration),
+      qtySent: item.quantity || "N/A",
+      qtyReceived: item.quantityReceived || "N/A",
+      qtyUoM: item.quantityReceivedPackagingUOMName,
+    })) || [];
+
+  if (!model) {
+    return <DataTableSkeleton role="progressbar" />;
+  }
+
+  return (
+    <div style={{ margin: "10px" }}>
+      <DataTable rows={rows} headers={headers}>
+        {({ rows, headers, getHeaderProps, getTableProps, getRowProps }) => (
+          <TableContainer>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map((header) => (
+                    <TableHeader
+                      {...getHeaderProps({ header })}
+                      key={header.key}
+                    >
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow {...getRowProps({ row })} key={row.id}>
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
+    </div>
+  );
+};
+
+export default ReceivedItems;

--- a/src/stock-operations/stock-operations-table.component.tsx
+++ b/src/stock-operations/stock-operations-table.component.tsx
@@ -435,11 +435,13 @@ const StockOperations: React.FC<StockOperationsTableProps> = () => {
                   />
 
                   <StockOperationsFilters
+                    conceptUuid={config.stockSourceTypeUUID}
                     filterName={StockFilters.STATUS}
                     onFilterChange={handleOnFilterChange}
                   />
 
                   <StockOperationsFilters
+                    conceptUuid={config.stockSourceTypeUUID}
                     filterName={StockFilters.OPERATION}
                     onFilterChange={handleOnFilterChange}
                   />
@@ -454,7 +456,7 @@ const StockOperations: React.FC<StockOperationsTableProps> = () => {
                   onOperationTypeSelected={(operation) => {
                     launchAddOrEditDialog(
                       t,
-                      initialStockOperationValue(),
+                      { ...initialStockOperationValue(), receivedItems: [] },
                       false,
                       operation,
                       operations,


### PR DESCRIPTION
## Summary
Show received stock items list after a stock issue operations has been dispatched. It allows A user  to see alist of stock items he/she received  only after a completed ,dispatched stock issue

## Screenshots
<img width="1680" alt="Screenshot 2024-08-06 at 10 43 59" src="https://github.com/user-attachments/assets/d7b88dc4-cd44-49da-a113-72c505b3c293">
<img width="1680" alt="Screenshot 2024-08-06 at 10 44 07" src="https://github.com/user-attachments/assets/7662e922-d282-4b01-a12d-bbbc1a5932e9">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3695

