### PR TITLE
Fix : Ensured the default Packaging Unit is selected

### DIFF
--- a/src/stock-items/add-stock-item/stock-item-units-edit/stock-item-units-edit.component.tsx
+++ b/src/stock-items/add-stock-item/stock-item-units-edit/stock-item-units-edit.component.tsx
@@ -21,7 +21,7 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
   const { t } = useTranslation();
 
   const { item: stockItem, isLoading } = useStockItem(stockItemUuid);
-  console.log(stockItem)
+
   if (
     !(
       stockItem &&
@@ -34,7 +34,9 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
   return (
     <>
       <DispensingPackageMeasurement
-        dispensingUnitPackagingUoMUuid={stockItem?.dispensingUnitPackagingUoMUuid}
+        dispensingUnitPackagingUoMUuid={
+          stockItem?.dispensingUnitPackagingUoMUuid
+        }
         name="dispensingUnitPackagingUoMUuid"
         controllerName="dispensingUnitPackagingUoMUuid"
         control={control}
@@ -52,7 +54,9 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
         }
       />
       <DispensingPackageMeasurement
-        dispensingUnitPackagingUoMUuid={stockItem?.defaultStockOperationsUoMUuid}
+        dispensingUnitPackagingUoMUuid={
+          stockItem?.defaultStockOperationsUoMUuid
+        }
         name="defaultStockOperationsUoMUuid"
         controllerName="defaultStockOperationsUoMUuid"
         control={control}

--- a/src/stock-items/add-stock-item/stock-item-units-edit/stock-item-units-edit.component.tsx
+++ b/src/stock-items/add-stock-item/stock-item-units-edit/stock-item-units-edit.component.tsx
@@ -21,7 +21,7 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
   const { t } = useTranslation();
 
   const { item: stockItem, isLoading } = useStockItem(stockItemUuid);
-
+  console.log(stockItem)
   if (
     !(
       stockItem &&
@@ -34,7 +34,7 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
   return (
     <>
       <DispensingPackageMeasurement
-        dispensingUnitPackagingUoMUuid={stockItem?.purchasePriceUoMUuid}
+        dispensingUnitPackagingUoMUuid={stockItem?.dispensingUnitPackagingUoMUuid}
         name="dispensingUnitPackagingUoMUuid"
         controllerName="dispensingUnitPackagingUoMUuid"
         control={control}
@@ -52,7 +52,7 @@ const StockItemUnitsEdit: React.FC<StockItemUnitsEditProps> = ({
         }
       />
       <DispensingPackageMeasurement
-        dispensingUnitPackagingUoMUuid={stockItem?.purchasePriceUoMUuid}
+        dispensingUnitPackagingUoMUuid={stockItem?.defaultStockOperationsUoMUuid}
         name="defaultStockOperationsUoMUuid"
         controllerName="defaultStockOperationsUoMUuid"
         control={control}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
Ensured the default Dispensing packaging unit and default stock operations packaging unit is selected on saving after editing or adding 

## Screenshots
[stock-default-selection.webm](https://github.com/user-attachments/assets/094a2e70-42c6-4891-b155-182c48ec4c1e)



## Related Issue
https://openmrs.atlassian.net/browse/O3-3703

## Other
<!-- Anything not covered above -->
<!-- *None* -->
