### PR TITLE
(fix) O3-3719: Stock-Item Details Fields Disabled in New Stock Issue

### DIFF
--- a/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
+++ b/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
@@ -98,7 +98,7 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
       await onSave(payload);
     } catch (e) {
       showSnackbar({
-        title: t("errorSavingBaseOperation", "Erro saving base operation"),
+        title: t("errorSavingBaseOperation", "Error saving base operation"),
         isLowContrast: true,
         kind: "error",
       });
@@ -181,17 +181,22 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
         )}
 
         {(!canEdit || isEditing || lockSource) && (
-          <TextInput
-            id="sourceUuidLbl"
-            value={
-              operationType === "stockissue"
-                ? issueStockOperation.sourceName
-                : model?.sourceName ?? ""
+          <PartySelector
+            controllerName="sourceUuid"
+            name="sourceUuid"
+            control={control}
+            title={operation?.hasDestination ? "From" : "Location"}
+            placeholder={
+              operation.hasDestination
+                ? t("chooseASource", "Choose a source")
+                : t("chooseALocation", "Choose a location")
             }
-            readOnly={true}
-            labelText={operation?.hasDestination ? "From" : "From"}
+            invalid={!!errors.sourceUuid}
+            invalidText={errors.sourceUuid && errors?.sourceUuid?.message}
+            parties={sourcePartyList || []}
           />
         )}
+
         {canEdit && !lockDestination && operation?.hasDestination && (
           <PartySelector
             controllerName="destinationUuid"
@@ -212,15 +217,21 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
         )}
 
         {(!canEdit || isEditing || lockDestination) && (
-          <TextInput
-            id="destinationUuidLbl"
-            value={
-              operationType === "stockissue"
-                ? issueStockOperation.destinationName
-                : model?.destinationName ?? ""
+          <PartySelector
+            controllerName="destinationUuid"
+            name="destinationUuid"
+            control={control}
+            title={operation?.hasSource ? "To" : "Location"}
+            placeholder={
+              operation?.hasSource
+                ? t("chooseADestination", "Choose a destination")
+                : "Location"
             }
-            readOnly={true}
-            labelText={operation?.hasSource ? "To" : "To"}
+            invalid={!!errors.destinationUuid}
+            invalidText={
+              errors.destinationUuid && errors?.destinationUuid?.message
+            }
+            parties={destinationPartyList || []}
           />
         )}
 
@@ -239,6 +250,8 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
             onUserChanged={(user) => {
               if (user?.uuid === otherUser.uuid) {
                 setIsOtherUser(true);
+              } else {
+                setIsOtherUser(false);
               }
             }}
           />
@@ -264,16 +277,24 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
         )}
 
         {!canEdit && (
-          <TextInput
-            id="responsiblePersonLbl"
-            value={
-              (model?.responsiblePersonUuid &&
-              model?.responsiblePersonUuid !== otherUser.uuid
-                ? `${model?.responsiblePersonFamilyName} ${model?.responsiblePersonGivenName}`
-                : model?.responsiblePersonOther) ?? ""
+          <UsersSelector
+            controllerName="responsiblePersonUuid"
+            name="responsiblePersonUuid"
+            control={control}
+            title={t("responsiblePerson:", "Responsible Person")}
+            placeholder={t("filter", "Filter ...")}
+            invalid={!!errors.responsiblePersonUuid}
+            invalidText={
+              errors.responsiblePersonUuid &&
+              errors?.responsiblePersonUuid?.message
             }
-            readOnly={true}
-            labelText={"Responsible Person"}
+            onUserChanged={(user) => {
+              if (user?.uuid === otherUser.uuid) {
+                setIsOtherUser(true);
+              } else {
+                setIsOtherUser(false);
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary
When performing a new stock issue operation, the stock-item details fields are now enabled. A dropdown list is displayed in each respective field


## Screenshots
<img width="1669" alt="Screenshot 2024-08-07 at 12 19 05" src="https://github.com/user-attachments/assets/40048d12-9e87-4a40-a960-3a16f47420dc">
<img width="1672" alt="Screenshot 2024-08-07 at 12 19 13" src="https://github.com/user-attachments/assets/dfb0c74a-7e90-4269-a416-5556983077e5">
<img width="1668" alt="Screenshot 2024-08-07 at 12 19 19" src="https://github.com/user-attachments/assets/fcca7db7-cf52-45b7-bb60-375cd505b78f">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3719

