### PR TITLE
(feat)  O3-3667: Adding a new operation and transferring out should show the stock balance

### DIFF
--- a/src/core/api/types/stockItem/StockItemInventory.ts
+++ b/src/core/api/types/stockItem/StockItemInventory.ts
@@ -8,4 +8,5 @@ export interface StockItemInventory {
   quantityUoM: string;
   quantityFactor: string;
   expiration: Date;
+  quantityUoMUuid?: string;
 }

--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -64,7 +64,11 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
     ) {
       setRequisition(props.model?.uuid);
     }
-  }, [currentStockOperationType, props.model?.operationType]);
+  }, [
+    currentStockOperationType,
+    props.model?.operationType,
+    props.model?.uuid,
+  ]);
 
   useEffect(() => {
     if (
@@ -79,7 +83,7 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
         setOperationLinks(resp.data?.results);
       });
     }
-  }, [currentStockOperationType, requisition, props.model?.uuid]);
+  }, [currentStockOperationType, requisition, props.model?.uuid, isEditing]);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [canDisplayReceivedItems, setCanDisplayReceivedItems] = useState(false);

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -137,9 +137,9 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
       item.stockItemPackagingUOMName = null;
 
       item.stockBatchUuid = null;
-      if (requiresBatchUuid) {
-        // handleStockBatchSearch(row, "", data.selectedItem?.uuid);
-      }
+
+      setValue(`stockItems.${index}.stockItemUuid`, item?.stockItemUuid);
+      setValue(`stockItems.${index}.stockItemName`, item?.stockItemName);
     }
   };
 
@@ -299,6 +299,11 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                           item?.expiration
                         );
 
+                        setValue(
+                          `stockItems.${index}.hasExpiration`,
+                          item?.expiration ? true : false
+                        );
+
                         setStockItemExpiries((prevExpiries) => ({
                           ...prevExpiries,
                           [index]: item?.expiration ?? null,
@@ -367,42 +372,34 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
             )}
             <TableCell>
               {canEdit && (
-                <>
-                  <NumberInput
-                    className="small-placeholder-text"
-                    size="sm"
-                    id={`qty-${row?.uuid}`}
-                    min={1}
-                    max={Number(currentBatchBalance?.quantity)}
-                    hideSteppers={true}
-                    allowEmpty={true}
-                    onChange={(e: any) => handleInputChange(e, index)}
-                    value={row?.quantity ?? ""}
-                    invalidText={
-                      errors?.stockItems?.[index]?.quantity?.message ||
-                      errors[`stockItems.${index}.quantity`]
-                    }
-                    placeholder={
-                      requiresBatchUuid &&
-                      !requiresActualBatchInformation &&
-                      currentBatchBalance
-                        ? `Bal: ${
-                            currentBatchBalance?.quantity?.toLocaleString() ??
-                            ""
-                          } ${currentBatchBalance?.quantityUoM ?? ""}`
-                        : ""
-                    }
-                    invalid={
-                      !!errors?.stockItems?.[index]?.quantity ||
-                      !!errors[`stockItems.${index}.quantity`]
-                    }
-                  />
-                  {errors[`stockItems.${index}.quantity`] && (
-                    <div className="error-message">
-                      {errors[`stockItems.${index}.quantity`]}
-                    </div>
-                  )}
-                </>
+                <NumberInput
+                  className="small-placeholder-text"
+                  size="sm"
+                  id={`qty-${row?.uuid}`}
+                  min={1}
+                  max={Number(currentBatchBalance?.quantity)}
+                  hideSteppers={true}
+                  allowEmpty={true}
+                  onChange={(e: any) => handleInputChange(e, index)}
+                  value={row?.quantity ?? ""}
+                  invalidText={
+                    errors?.stockItems?.[index]?.quantity?.message ||
+                    qtyInputErrors[`stockItems.${index}.quantity`]
+                  }
+                  placeholder={
+                    requiresBatchUuid &&
+                    !requiresActualBatchInformation &&
+                    currentBatchBalance
+                      ? `Bal: ${
+                          currentBatchBalance?.quantity?.toLocaleString() ?? ""
+                        } ${currentBatchBalance?.quantityUoM ?? ""}`
+                      : ""
+                  }
+                  invalid={
+                    !!errors?.stockItems?.[index]?.quantity ||
+                    !!qtyInputErrors[`stockItems.${index}.quantity`]
+                  }
+                />
               )}
               {!canEdit && row?.quantity?.toLocaleString()}
             </TableCell>
@@ -413,7 +410,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                 : "N/A"}
               {!canEdit && row?.stockItemPackagingUOMName}
             </TableCell>
-            {canCapturePurchasePrice && (
+            {canCapturePurchasePrice ? (
               <TableCell>
                 {canEdit && (
                   <NumberInput
@@ -434,6 +431,8 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                 )}
                 {!canEdit && row?.purchasePrice?.toLocaleString()}
               </TableCell>
+            ) : (
+              setValue(`stockItems.${index}.purchasePrice`, null)
             )}
             {canEdit && (
               <TableCell>

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -107,7 +107,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
     Date | null | undefined
   >();
   const [batchBalance, setBatchBalance] = useState(null);
-
+  console.log(batchBalance, "bal");
   const handleStockItemChange = (index: number, data?: StockItemDTO) => {
     if (!data) return;
     const item = fields[index];
@@ -162,6 +162,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
           const inventory: StockItemInventory = (
             res?.results as StockItemInventory[]
           )?.[0];
+          console.log(inventory, "inve");
           if (!inventory) {
             setBatchBalance({
               quantity: 0,
@@ -171,6 +172,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
           setBatchBalance({
             quantity: inventory.quantity,
             quantityUoM: inventory.quantityUoM,
+            quantityUoMUuid: inventory.quantityUoMUuid,
           });
         })
         .catch((error: any) => {
@@ -299,7 +301,9 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                         id={`expiration-input-${row.uuid}`}
                         name="operationDate"
                         placeholder={DATE_PICKER_FORMAT}
-                        defaultValue={formatForDatePicker(row?.expiration)}
+                        defaultValue={formatForDatePicker(
+                          stockItemExpiry || row?.expiration
+                        )}
                         invalid={!!errors?.stockItems?.[index]?.expiration}
                       />
                     </DatePicker>

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -12,6 +12,7 @@ import {
 } from "@carbon/react";
 import { TrashCan } from "@carbon/react/icons";
 import { StockOperationItemFormData } from "../validation-schema";
+import QtyUomSelector from "../qty-uom-selector/qty-uom-selector.component";
 import StockItemSelector from "../stock-item-selector/stock-item-selector.component";
 import {
   Control,
@@ -405,9 +406,29 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
             </TableCell>
             {/* Qty UoM Cell (Non-editable) */}
             <TableCell>
-              {currentBatchBalance?.quantityUoM
-                ? currentBatchBalance.quantityUoM
-                : row?.stockItemPackagingUOMName}
+              {canEdit && !currentBatchBalance?.quantityUoM ? (
+                <QtyUomSelector
+                  stockItemUuid={row.stockItemUuid}
+                  onStockPackageChanged={(selectedItem) => {
+                    setValue(
+                      `stockItems.${index}.stockItemPackagingUOMUuid`,
+                      selectedItem?.uuid
+                    );
+                  }}
+                  placeholder={"Filter..."}
+                  invalid={
+                    !!errors?.stockItems?.[index]?.stockItemPackagingUOMUuid
+                  }
+                  control={control as unknown as Control}
+                  controllerName={`stockItems.${index}.stockItemPackagingUOMUuid`}
+                  name={`stockItems.${index}.stockItemPackagingUOMUuid`}
+                />
+              ) : currentBatchBalance?.quantityUoM ? (
+                currentBatchBalance.quantityUoM
+              ) : (
+                row?.stockItemPackagingUOMName
+              )}
+
               {!canEdit && row?.stockItemPackagingUOMName}
             </TableCell>
             {canCapturePurchasePrice ? (

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -407,7 +407,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
             <TableCell>
               {currentBatchBalance?.quantityUoM
                 ? currentBatchBalance.quantityUoM
-                : "N/A"}
+                : row?.stockItemPackagingUOMName}
               {!canEdit && row?.stockItemPackagingUOMName}
             </TableCell>
             {canCapturePurchasePrice ? (

--- a/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
@@ -241,6 +241,8 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
                         { uuid: `new-item-1`, id: `new-item-1` },
                       ]
                     }
+                    stockOperationUuid={model.uuid ?? ""}
+                    locationUuid={model.atLocationUuid ?? ""}
                     batchBalance={batchBalance}
                     batchNos={batchNos}
                     control={control}

--- a/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
+++ b/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
@@ -62,6 +62,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
   const filteredBatches = stockItemBatchesInfo?.filter(
     (s) => s.quantity !== undefined
   );
+
   useEffect(() => {
     if (
       !isLoading &&
@@ -101,7 +102,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
             }}
             initialSelectedItem={initialSelectedItem}
             itemToString={(s: StockBatchDTO) =>
-              s?.batchNo ? `${s?.batchNo} | Qty: ${s?.quantity ?? ""}` : ""
+              s?.batchNo ? `${s?.batchNo}` : ""
             }
             placeholder={props.placeholder}
             invalid={props.invalid}

--- a/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
+++ b/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
@@ -59,6 +59,9 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
     return item;
   });
 
+  const filteredBatches = stockItemBatchesInfo?.filter(
+    (s) => s.quantity !== undefined
+  );
   useEffect(() => {
     if (
       !isLoading &&
@@ -90,7 +93,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
             controllerName={props.controllerName}
             id={props.name}
             size={"sm"}
-            items={stockItemBatchesInfo || []}
+            items={filteredBatches || []}
             onChange={(data: { selectedItem?: StockBatchDTO }) => {
               setSelectedItem(data.selectedItem || null);
               props.onBatchNoChanged?.(data.selectedItem);

--- a/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
+++ b/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
@@ -60,7 +60,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
   });
 
   const filteredBatches = stockItemBatchesInfo?.filter(
-    (s) => s.quantity !== undefined
+    (s) => s.quantity !== undefined && s.quantity !== 0
   );
 
   useEffect(() => {
@@ -68,7 +68,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
       !isLoading &&
       stockItemBatchNos &&
       props.selectedItem &&
-      stockItemBatchNos.length === 0
+      (stockItemBatchNos.length === 0 || filteredBatches.length === 0)
     ) {
       setValidationMessage(
         "No stock batch numbers defined. Do a initial/receipt stock operation first."
@@ -76,7 +76,7 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
     } else {
       setValidationMessage(null);
     }
-  }, [isLoading, stockItemBatchNos, props.selectedItem]);
+  }, [isLoading, stockItemBatchNos, props.selectedItem, filteredBatches]);
 
   if (isLoading) return <InlineLoading status="active" />;
 

--- a/src/stock-operations/stock-item-selector/stock-item-selector.component.tsx
+++ b/src/stock-operations/stock-item-selector/stock-item-selector.component.tsx
@@ -68,7 +68,7 @@ const StockItemSelector = <T,>(props: StockItemSelectorProps<T>) => {
 };
 
 function stockItemName(item: StockItemDTO): string {
-  return item.drugName || item.conceptName;
+  return item?.drugName || item?.conceptName;
 }
 
 export default StockItemSelector;

--- a/src/stock-operations/stock-operations.resource.ts
+++ b/src/stock-operations/stock-operations.resource.ts
@@ -210,7 +210,7 @@ export function getStockOperationItemsCost(filter: StockOperationFilter) {
 export function getStockItemInventory(filter: StockItemInventoryFilter) {
   const apiUrl = `${restBaseUrl}/stockmanagement/stockiteminventory${toQueryParams(
     filter
-  )}`;
+  )}&v=default`;
   const abortController = new AbortController();
   return openmrsFetch(apiUrl, {
     method: "GET",


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Fetch inventory balance once a batch is selected and show it as a placeholder

## Screenshots
<img width="1727" alt="Screenshot 2024-08-09 at 12 26 51" src="https://github.com/user-attachments/assets/7877507b-293f-42e4-bf9a-a4602d05e574">


https://github.com/user-attachments/assets/1212bfba-2445-4da8-be0e-b34d1f8d45e0


## Related Issue
- https://openmrs.atlassian.net/browse/O3-3667

## Other
<!-- Anything not covered above -->
<!-- *None* -->
