### PR TITLE
(fix) O3-3819 :  set logged-in user as default responsible person in stock management forms

### DIFF
--- a/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
+++ b/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { StockOperationDTO } from "../../core/api/types/stockOperation/StockOperationDTO";
 import { SaveStockOperation } from "../../stock-items/types";
@@ -83,6 +83,12 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
 
   const [isOtherUser, setIsOtherUser] = useState<boolean | null>();
   const [isSaving, setIsSaving] = useState(false);
+  useEffect(() => {
+    if (defaultLoggedUserUuid) {
+      setValue("responsiblePersonUuid", defaultLoggedUserUuid);
+    }
+  }, [defaultLoggedUserUuid, setValue]);
+
   if (isLoading) {
     return (
       <InlineLoading


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->
Continuation: https://openmrs.atlassian.net/browse/O3-3732
See: https://openmrs.atlassian.net/browse/O3-3819

Form Before:
![responsiblepersonb4](https://github.com/user-attachments/assets/26be6d93-2f2c-4766-90c8-ce688767d4ba)

Form After:
![responsiblepersonafter](https://github.com/user-attachments/assets/5499f196-f4bc-418e-a61e-79fa1024934b)


## Other
<!-- Anything not covered above -->
<!-- *None* -->
