### PR TITLE
(Fix): O3-3900-Stock Operation Name is not maintained when editing

### DIFF
--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -113,7 +113,7 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
   const tabs: TabItem[] = [
     {
       name: isEditing
-        ? `${props?.model?.operationTypeName} Details`
+        ? `${props?.operation?.name} Details`
         : `${props?.operation?.name} Details`,
       component: (
         <BaseOperationDetails


### PR DESCRIPTION
## Summary
While editing a stock operation, the operation name is not maintained through the editing process. This has been resolved

## Screenshots
<img width="1440" alt="Screenshot 2024-09-02 at 14 09 49" src="https://github.com/user-attachments/assets/d0c815f0-23d3-41d2-a8ab-9a86db591501">

## Related Issue
https://openmrs.atlassian.net/browse/O3-3900