### PR TITLE
(Test) O3-3754: Add unit tests for the Items table

### DIFF
--- a/src/stock-items/stock-items-table.component.tsx
+++ b/src/stock-items/stock-items-table.component.tsx
@@ -187,7 +187,7 @@ const StockItemsTableComponent: React.FC<StockItemsTableProps> = () => {
 
                 <FilterStockItems filterType={isDrug} changeFilterType={setDrug} />
                 <AddStockItemsBulktImportActionButton />
-                <TableToolbarMenu>
+                <TableToolbarMenu data-testid="stock-items-menu">
                   <TableToolbarAction onClick={handleRefresh}>Refresh</TableToolbarAction>
                 </TableToolbarMenu>
                 <AddStockItemActionButton />

--- a/src/stock-items/stock-items-table.test.tsx
+++ b/src/stock-items/stock-items-table.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import StockItemsTableComponent from './stock-items-table.component';
+import { useStockItemsPages } from './stock-items-table.resource';
+import { handleMutate } from '../utils';
+import { launchAddOrEditDialog } from './stock-item.utils';
+
+jest.mock('./stock-items-table.resource', () => ({
+  useStockItemsPages: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  handleMutate: jest.fn(),
+}));
+
+jest.mock('./stock-item.utils', () => ({
+  launchAddOrEditDialog: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('StockItemsTableComponent', () => {
+  const mockUseStockItemsPages = {
+    isLoading: false,
+    items: Array(25).fill(null).map((_, index) => ({
+      uuid: `item-${index}`,
+      commonName: `Test Item ${index}`,
+      drugUuid: index % 2 === 0 ? `drug-${index}` : null,
+      conceptName: `Concept ${index}`,
+      dispensingUnitName: `Unit ${index}`,
+      defaultStockOperationsUoMName: `UoM ${index}`,
+      reorderLevel: index * 10,
+      reorderLevelUoMName: 'Units',
+    })),
+    totalCount: 25,
+    currentPageSize: 10,
+    setPageSize: jest.fn(),
+    pageSizes: [10, 20, 30],
+    currentPage: 1,
+    setCurrentPage: jest.fn(),
+    isDrug: '',
+    setDrug: jest.fn(),
+    setSearchString: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useStockItemsPages as jest.Mock).mockReturnValue(mockUseStockItemsPages);
+  });
+
+  it('renders initial state and UI elements correctly', async () => {
+    render(<StockItemsTableComponent />);
+    expect(screen.getByText('panelDescription')).toBeInTheDocument();
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    
+    const menuButton = screen.getByTestId('stock-items-menu');
+    fireEvent.click(menuButton);
+  
+    await screen.findByText('Refresh');
+    
+    expect(screen.getByText('type')).toBeInTheDocument();
+    expect(screen.getByText('genericName')).toBeInTheDocument();
+    expect(screen.getByText('commonName')).toBeInTheDocument();
+  });
+
+  it('displays skeleton loader when isLoading is true', () => {
+    (useStockItemsPages as jest.Mock).mockReturnValue({ ...mockUseStockItemsPages, isLoading: true });
+    render(<StockItemsTableComponent />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders table rows correctly based on items prop', () => {
+    render(<StockItemsTableComponent />);
+    expect(screen.getByText('Test Item 0')).toBeInTheDocument();
+    expect(screen.getAllByText('drug').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('other').length).toBeGreaterThan(0);
+  });
+
+  it('updates search input and triggers search function', async () => {
+    render(<StockItemsTableComponent />);
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.change(searchInput, { target: { value: 'test search' } });
+    await waitFor(() => {
+      expect(mockUseStockItemsPages.setSearchString).toHaveBeenCalledWith('test search');
+    }, { timeout: 2000 });
+  });
+
+  it('updates pagination when page or page size changes', () => {
+    render(<StockItemsTableComponent />);
+    const nextPageButton = screen.getByLabelText('Next page');
+    fireEvent.click(nextPageButton);
+    expect(mockUseStockItemsPages.setCurrentPage).toHaveBeenCalled();
+
+    const pageSizeSelect = screen.getByLabelText('Items per page:');
+    fireEvent.change(pageSizeSelect, { target: { value: '20' } });
+    expect(mockUseStockItemsPages.setPageSize).toHaveBeenCalledWith(20);
+  });
+
+  it('triggers handleRefresh when refresh button is clicked', async () => {
+    render(<StockItemsTableComponent />);
+    
+    const menuButton = screen.getByTestId('stock-items-menu');
+    expect(menuButton).toBeInTheDocument();
+    fireEvent.click(menuButton);
+  
+    const refreshButton = await screen.findByText('Refresh');
+    expect(refreshButton).toBeInTheDocument();
+    fireEvent.click(refreshButton);
+    await waitFor(() => {
+      expect(handleMutate).toHaveBeenCalledWith(expect.stringContaining('/stockmanagement/stockitem'));
+    });
+  });
+
+  it('triggers launchAddOrEditDialog when edit button is clicked', () => {
+    render(<StockItemsTableComponent />);
+    const editButtons = screen.getAllByLabelText('Edit Stock Item');
+    fireEvent.click(editButtons[0]);
+    expect(launchAddOrEditDialog).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ uuid: 'item-0' }),
+      true
+    );
+  });
+});

--- a/src/stock-items/stock-items-table.test.tsx
+++ b/src/stock-items/stock-items-table.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import StockItemsTableComponent from './stock-items-table.component';
 import { useStockItemsPages } from './stock-items-table.resource';
 import { handleMutate } from '../utils';
@@ -57,8 +58,9 @@ describe('StockItemsTableComponent', () => {
     expect(screen.getByText('panelDescription')).toBeInTheDocument();
     expect(screen.getByRole('searchbox')).toBeInTheDocument();
     
+    const user = userEvent.setup();
     const menuButton = screen.getByTestId('stock-items-menu');
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
   
     await screen.findByText('Refresh');
     
@@ -82,43 +84,47 @@ describe('StockItemsTableComponent', () => {
 
   it('updates search input and triggers search function', async () => {
     render(<StockItemsTableComponent />);
+    const user = userEvent.setup();
     const searchInput = screen.getByRole('searchbox');
-    fireEvent.change(searchInput, { target: { value: 'test search' } });
+    await user.type(searchInput, 'test search');
     await waitFor(() => {
       expect(mockUseStockItemsPages.setSearchString).toHaveBeenCalledWith('test search');
     }, { timeout: 2000 });
   });
 
-  it('updates pagination when page or page size changes', () => {
+  it('updates pagination when page or page size changes', async () => {
     render(<StockItemsTableComponent />);
+    const user = userEvent.setup();
     const nextPageButton = screen.getByLabelText('Next page');
-    fireEvent.click(nextPageButton);
+    await user.click(nextPageButton);
     expect(mockUseStockItemsPages.setCurrentPage).toHaveBeenCalled();
 
     const pageSizeSelect = screen.getByLabelText('Items per page:');
-    fireEvent.change(pageSizeSelect, { target: { value: '20' } });
+    await user.selectOptions(pageSizeSelect, '20');
     expect(mockUseStockItemsPages.setPageSize).toHaveBeenCalledWith(20);
   });
 
   it('triggers handleRefresh when refresh button is clicked', async () => {
     render(<StockItemsTableComponent />);
     
+    const user = userEvent.setup();
     const menuButton = screen.getByTestId('stock-items-menu');
     expect(menuButton).toBeInTheDocument();
-    fireEvent.click(menuButton);
+    await user.click(menuButton);
   
     const refreshButton = await screen.findByText('Refresh');
     expect(refreshButton).toBeInTheDocument();
-    fireEvent.click(refreshButton);
+    await user.click(refreshButton);
     await waitFor(() => {
       expect(handleMutate).toHaveBeenCalledWith(expect.stringContaining('/stockmanagement/stockitem'));
     });
   });
 
-  it('triggers launchAddOrEditDialog when edit button is clicked', () => {
+  it('triggers launchAddOrEditDialog when edit button is clicked', async () => {
     render(<StockItemsTableComponent />);
+    const user = userEvent.setup();
     const editButtons = screen.getAllByLabelText('Edit Stock Item');
-    fireEvent.click(editButtons[0]);
+    await user.click(editButtons[0]);
     expect(launchAddOrEditDialog).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({ uuid: 'item-0' }),

--- a/src/stock-sources/add-stock-sources/add-stock-sources.test.tsx
+++ b/src/stock-sources/add-stock-sources/add-stock-sources.test.tsx
@@ -41,7 +41,7 @@ describe('StockSourcesAddOrUpdate', () => {
 
   it('renders correctly with model prop', () => {
     const model: StockSource = {
-      uuid: '123', // Add this
+      uuid: '123',
       name: 'Test Source',
       acronym: 'TS',
       sourceType: {
@@ -72,7 +72,6 @@ describe('StockSourcesAddOrUpdate', () => {
         retiredBy: undefined,
         retireReason: '',
       },
-      // Add these properties from BaseOpenmrsData
       creator: {
         uuid: 'creator-uuid',
         display: 'Creator Name',
@@ -115,13 +114,14 @@ describe('StockSourcesAddOrUpdate', () => {
 
     await user.type(screen.getByLabelText('Full Name'), 'New Source');
     await user.type(screen.getByLabelText('Acronym/Code'), 'NS');
-    await user.type(screen.getByLabelText('Source Type'), 'type2');
+    await user.selectOptions(screen.getByLabelText('Source Type'), 'type2');
     await user.click(screen.getByText('Save'));
 
     expect(createOrUpdateStockSource).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'New Source',
         acronym: 'NS',
+        sourceType: expect.objectContaining({ uuid: 'type2' }),
       }),
     );
   });


### PR DESCRIPTION
## Summary
Consists of tests that ensure that the component renders correctly, 
Verifies that the component renders with the initial state and UI elements are correctly displayed.
Tests that the skeleton loader is displayed when isLoading is true.
Tests that the table rows are rendered correctly based on the items prop.
Tests the search input to ensure it updates the state and triggers the search function correctly. 
Tests the pagination controls to ensure they update the current page and page size correctly.
Tests that clicking the refresh button triggers the handleRefresh function.
Tests that clicking the edit button on a row triggers the launchAddOrEditDialog function with the correct arguments.


## Related Issue
https://openmrs.atlassian.net/browse/O3-3754

