### PR TITLE
(fix) Disable number input scroll wheel functionality

### DIFF
--- a/src/core/components/carbon/controlled-number-input/controlled-number-input.component.tsx
+++ b/src/core/components/carbon/controlled-number-input/controlled-number-input.component.tsx
@@ -19,6 +19,7 @@ const ControlledNumberInput = <T,>(props: ControlledNumberInputProps<T>) => {
       control={props.control}
       render={({ field: { onChange, value, ref } }) => (
         <NumberInput
+          disableWheel
           label={props.label}
           id={`${props.name}-${props.id}-${props.row?.uuid}`}
           value={props.row?.factor ?? value}

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -3,7 +3,6 @@ import { isDesktop } from '@openmrs/esm-framework';
 import { Button, DatePicker, DatePickerInput, Link, NumberInput, TableCell, TableRow, TextInput } from '@carbon/react';
 import { TrashCan } from '@carbon/react/icons';
 import { StockOperationItemFormData } from '../validation-schema';
-import StockItemSelector from '../stock-item-selector/stock-item-selector.component';
 import {
   Control,
   FieldArrayWithId,
@@ -217,11 +216,12 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
               <div className={styles.cellContent}>
                 {canEdit && (
                   <NumberInput
+                    allowEmpty
                     className="small-placeholder-text"
+                    disableWheel
+                    hideSteppers
                     size="sm"
                     id={`qty-${row?.uuid}`}
-                    hideSteppers={true}
-                    allowEmpty={true}
                     onChange={(e: any) => setValue(`stockItems.${index}.quantity`, e?.target?.value)}
                     value={row?.quantity ?? ''}
                     invalidText={errors?.stockItems?.[index]?.quantity?.message}
@@ -262,11 +262,12 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                   <div className={styles.cellContent}>
                     {canEdit && (
                       <NumberInput
+                        allowEmpty
+                        disableWheel
                         size="sm"
                         invalid={!!errors?.stockItems?.[index]?.purchasePrice}
                         invalidText=""
                         id={`purchaseprice-${row.uuid}`}
-                        allowEmpty={true}
                         onChange={(e: any) => setValue(`stockItems.${index}.purchasePrice`, e?.target?.value)}
                         value={row?.purchasePrice ?? ''}
                         title=""

--- a/src/stock-reports/generate-report/create-stock-report.component.tsx
+++ b/src/stock-reports/generate-report/create-stock-report.component.tsx
@@ -522,8 +522,9 @@ const CreateReport: React.FC<CreateReportProps> = ({ model }) => {
             render={({ field: { onChange, value } }) => (
               <NumberInput
                 id="limitTop"
-                allowEmpty={true}
-                hideSteppers={true}
+                allowEmpty
+                disableWheel
+                hideSteppers
                 value={value}
                 onchange={onChange}
                 label={t('limit', 'Limit')}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR disables the scroll wheel functionality in [NumberInput](https://react.carbondesignsystem.com/?path=/docs/components-numberinput--overview) fields in the Stock Management app by setting the `disableWheel` prop. Before this change, when a NumberInput field was focused and the user scrolled past with their mouse wheel, the value in the input would increment or decrement. This can lead to accidental value changes that the user might overlook. Setting the prop fixes makes the NumberInput ignore mouse wheel events when focused, reducing the likelihood of unintentional value changes.

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
