### PR TITLE
(feat)- O3-3966: At stock requisition, user should be able to see the number of the stock item and its availability

### DIFF
--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -134,6 +134,22 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                 </Link>
               )}
             </TableCell>
+            <TableCell>
+              <div className={styles.cellContent}>
+                {row?.stockItemUuid && (
+                  <>
+                    <div>{`#${row?.stockItemUuid?.toString()?.slice(0, 8)}`}</div>
+                    <div className={styles.availability}>
+                      {batchBalance?.[row?.stockBatchUuid]
+                        ? `Available: ${batchBalance[row?.stockBatchUuid]?.quantity?.toLocaleString() ?? 0} ${
+                            batchBalance[row?.stockBatchUuid]?.quantityUoM ?? ''
+                          }`
+                        : 'No stock available'}
+                    </div>
+                  </>
+                )}
+              </div>
+            </TableCell>
             {showQuantityRequested && (
               <TableCell>
                 <div className={styles.cellContent}>

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useMemo, useState } from 'react';
 import { isDesktop } from '@openmrs/esm-framework';
 import { Button, DatePicker, DatePickerInput, Link, NumberInput, TableCell, TableRow, TextInput } from '@carbon/react';
 import { TrashCan } from '@carbon/react/icons';
@@ -27,6 +27,7 @@ import QtyUomSelector from '../qty-uom-selector/qty-uom-selector.component';
 import BatchNoSelector from '../batch-no-selector/batch-no-selector.component';
 
 import styles from './stock-items-addition-row.scss';
+import { useStockItemBatchInformationHook } from '../../stock-items/add-stock-item/batch-information/batch-information.resource';
 
 interface StockItemsAdditionRowProps {
   canEdit?: boolean;
@@ -117,6 +118,36 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
   const isStockItem = (obj: any): obj is StockItemDTO => {
     return typeof obj === 'object' && obj !== null && 'drugName' in obj;
   };
+
+  const StockAvailability: React.FC<{ stockItemUuid: string }> = ({ stockItemUuid }) => {
+    const { items } = useStockItemBatchInformationHook({
+      stockItemUuid: stockItemUuid,
+      includeBatchNo: true,
+    });
+
+    const totalQuantity = useMemo(() => {
+      if (!items?.length) return 0;
+      return items.reduce((total, batch) => {
+        return total + (Number(batch.quantity) || 0);
+      }, 0);
+    }, [items]);
+    const commonUOM = useMemo(() => {
+      if (!items?.length) return '';
+      return items[0]?.quantityUoM || '';
+    }, [items]);
+
+    return (
+      <div className={styles.availability}>
+        {totalQuantity > 0 ? (
+          <span>
+            Available: {totalQuantity.toLocaleString()} {commonUOM}
+          </span>
+        ) : (
+          <span className={styles.outOfStock}>Out of Stock</span>
+        )}
+      </div>
+    );
+  };
   return (
     <>
       {fields?.map((row, index) => {
@@ -136,18 +167,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
             </TableCell>
             <TableCell>
               <div className={styles.cellContent}>
-                {row?.stockItemUuid && (
-                  <>
-                    <div>{`#${row?.stockItemUuid?.toString()?.slice(0, 8)}`}</div>
-                    <div className={styles.availability}>
-                      {batchBalance?.[row?.stockBatchUuid]
-                        ? `Available: ${batchBalance[row?.stockBatchUuid]?.quantity?.toLocaleString() ?? 0} ${
-                            batchBalance[row?.stockBatchUuid]?.quantityUoM ?? ''
-                          }`
-                        : 'No stock available'}
-                    </div>
-                  </>
-                )}
+                {row?.stockItemUuid && <StockAvailability stockItemUuid={row.stockItemUuid} />}
               </div>
             </TableCell>
             {showQuantityRequested && (

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.scss
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.scss
@@ -1,5 +1,12 @@
 .availability {
   font-size: 0.875rem;
-  color: #525252;
-  margin-top: 0.25rem;
+
+  .outOfStock {
+    color: #da1e28;
+  }
+}
+.cellContent {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.scss
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.scss
@@ -1,0 +1,5 @@
+.availability {
+  font-size: 0.875rem;
+  color: #525252;
+  margin-top: 0.25rem;
+}

--- a/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
@@ -107,6 +107,11 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
       header: t('item', 'Item'),
       styles: { width: '40% !important' },
     },
+    {
+      key: 'itemDetails',
+      header: t('itemDetails', 'Item Details'),
+      styles: { width: '20% !important' },
+    },
     ...(showQuantityRequested
       ? [
           {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR allows the user to see if a stock item is 'Out of Stock' or 'Available' as well as the total quantity of the stock item available across all its batches.

## Screenshots
<img width="1440" alt="Screenshot 2024-11-13 at 13 43 40" src="https://github.com/user-attachments/assets/a00a4585-a706-4cc2-89fd-a5c10b4df316">




## Related Issue
https://openmrs.atlassian.net/browse/O3-3966

## Other
<!-- Anything not covered above -->
