### PR TITLE
(fix):O3-4209 Enhance stock operation validations to support negative stock adjustments

### DIFF
--- a/src/stock-operations/add-stock-operation/validationSchema.ts
+++ b/src/stock-operations/add-stock-operation/validationSchema.ts
@@ -37,5 +37,18 @@ export function useValidationSchema(operationType?: string) {
       stockItems: z.array(customSchema),
     });
   }
+  if (operationType === 'adjustment') {
+    const customSchema = stockItemTableSchema.extend({
+      quantity: z.coerce
+        .number()
+        .refine((value) => value !== 0, {
+          message: 'Quantity cannot be zero.',
+        })
+        .or(z.literal(0, { invalid_type_error: 'Invalid quantity format' })),
+    });
+    return z.object({
+      stockItems: z.array(customSchema),
+    });
+  }
   return stockOperationItemsSchema;
 }


### PR DESCRIPTION


## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The quantity field in stock operations is currently validated to prevent the entry of negative numbers. However, for negative stock adjustments, entering negative quantities should be permitted to reflect accurate adjustments. This validation should be updated to allow negative values specifically for negative stock adjustment operations.
## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 19-11-2024 10:52:13 ASUBUHI.webm](https://github.com/user-attachments/assets/362cf2a4-e066-4139-a9dd-96d8d9340af3)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4209
## Other
<!-- Anything not covered above -->
