### PR TITLE
(fix) Autopopulate responsible person in stocks operation

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -5,6 +5,11 @@ export const configSchema = {
     _default: false,
     _description: 'Whether to print item costs on the print out',
   },
+  autoPopulateResponsiblePerson: {
+    type: Type.Boolean,
+    _default: true,
+    _description: 'Auto Populate Responsible person in stock operations with the currently logged in user',
+  },
   printBalanceOnHand: {
     type: Type.Boolean,
     _default: false,
@@ -55,6 +60,7 @@ export const configSchema = {
 };
 
 export type ConfigObject = {
+  autoPopulateResponsiblePerson: boolean;
   printItemCost: boolean;
   printBalanceOnHand: boolean;
   packagingUnitsUUID: string;

--- a/src/stock-operations/users-selector/users-selector.component.tsx
+++ b/src/stock-operations/users-selector/users-selector.component.tsx
@@ -5,8 +5,8 @@ import { ComboBox, InlineLoading } from '@carbon/react';
 import { useUsersHook } from './users-selector.resource';
 import { useDebounce } from '../../core/hooks/debounce-hook';
 import { otherUser } from '../../core/utils/utils';
-import { useSession } from '@openmrs/esm-framework';
-import { use } from 'i18next';
+import { useConfig, useSession } from '@openmrs/esm-framework';
+import { ConfigObject } from '../../config-schema';
 
 interface UsersSelectorProps<T> {
   placeholder?: string;
@@ -25,6 +25,7 @@ interface UsersSelectorProps<T> {
 const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
   const { isLoading, userList, setSearchString } = useUsersHook();
   const { user } = useSession();
+  const { autoPopulateResponsiblePerson } = useConfig<ConfigObject>();
 
   const debouncedSearch = useDebounce((query: string) => {
     setSearchString(query);
@@ -39,7 +40,7 @@ const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
         control={props.control}
         render={({ field: { onChange, ref } }) => (
           <ComboBox
-            disabled={true}
+            disabled={autoPopulateResponsiblePerson ? true : false}
             titleText={props.title}
             name={props.name}
             control={props.control}
@@ -51,7 +52,9 @@ const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
               props.onUserChanged?.(data.selectedItem);
               onChange(data.selectedItem?.uuid);
             }}
-            initialSelectedItem={userList?.find((p) => p.uuid === user.uuid) ?? ''}
+            initialSelectedItem={
+              userList?.find((p) => p.uuid === (autoPopulateResponsiblePerson ? user.uuid : props.userUuid)) ?? ''
+            }
             itemToString={userName}
             onInputChange={debouncedSearch}
             placeholder={props.placeholder}

--- a/src/stock-operations/users-selector/users-selector.component.tsx
+++ b/src/stock-operations/users-selector/users-selector.component.tsx
@@ -1,10 +1,12 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { Control, Controller, FieldValues } from 'react-hook-form';
 import { User } from '../../core/api/types/identity/User';
 import { ComboBox, InlineLoading } from '@carbon/react';
 import { useUsersHook } from './users-selector.resource';
 import { useDebounce } from '../../core/hooks/debounce-hook';
 import { otherUser } from '../../core/utils/utils';
+import { useSession } from '@openmrs/esm-framework';
+import { use } from 'i18next';
 
 interface UsersSelectorProps<T> {
   placeholder?: string;
@@ -22,6 +24,7 @@ interface UsersSelectorProps<T> {
 
 const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
   const { isLoading, userList, setSearchString } = useUsersHook();
+  const { user } = useSession();
 
   const debouncedSearch = useDebounce((query: string) => {
     setSearchString(query);
@@ -36,6 +39,7 @@ const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
         control={props.control}
         render={({ field: { onChange, ref } }) => (
           <ComboBox
+            disabled={true}
             titleText={props.title}
             name={props.name}
             control={props.control}
@@ -47,7 +51,7 @@ const UsersSelector = <T,>(props: UsersSelectorProps<T>) => {
               props.onUserChanged?.(data.selectedItem);
               onChange(data.selectedItem?.uuid);
             }}
-            initialSelectedItem={userList?.find((p) => p.uuid === props.userUuid) ?? ''}
+            initialSelectedItem={userList?.find((p) => p.uuid === user.uuid) ?? ''}
             itemToString={userName}
             onInputChange={debouncedSearch}
             placeholder={props.placeholder}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
this fix Auto populates responsible person in stocks operation. This means that the responsible person will automatically be the logged in person. However i have added **autoPopulateResponsiblePerson** item to configurations to enable or disable this feature based on various use cases

## Screenshots
![Screenshot from 2024-12-12 10-25-47](https://github.com/user-attachments/assets/22048fb8-41f3-41b1-867a-420688873ee3)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
