### PR TITLE
(feat):Make stock transactions print button configurable.

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -5,6 +5,11 @@ export const configSchema = {
     _default: false,
     _description: 'Whether to print item costs on the print out',
   },
+  enablePrintButton: {
+    _type: Type.Boolean,
+    _default: true,
+    _description: 'Enable or disable the print button in the stock management UI',
+  },
   autoPopulateResponsiblePerson: {
     type: Type.Boolean,
     _default: false,
@@ -61,6 +66,7 @@ export const configSchema = {
 
 export type ConfigObject = {
   autoPopulateResponsiblePerson: boolean;
+  enablePrintButton: boolean;
   printItemCost: boolean;
   printBalanceOnHand: boolean;
   packagingUnitsUUID: string;

--- a/src/stock-items/add-stock-item/transactions/printout/transactions-print-action.component.tsx
+++ b/src/stock-items/add-stock-item/transactions/printout/transactions-print-action.component.tsx
@@ -3,7 +3,8 @@ import { Button, Stack, ComboButton, MenuItem } from '@carbon/react';
 import { Printer } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { useStockItem } from '../../../stock-items.resource';
-import { showModal } from '@openmrs/esm-framework';
+import { showModal, useConfig } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../../../../config-schema';
 import styles from './printable-transaction.scss';
 import { useEffect, useMemo, useState } from 'react';
 import { StockItemInventoryFilter, useStockItemTransactions } from '../../../stock-items.resource';
@@ -17,6 +18,8 @@ type Props = {
 
 const TransactionsPrintAction: React.FC<Props> = ({ columns, data, itemUuid }) => {
   const { t } = useTranslation();
+
+  const { enablePrintButton } = useConfig<ConfigObject>();
 
   const [stockCardItemFilter, setStockCardItemFilter] = useState<StockItemInventoryFilter>({
     startIndex: 0,
@@ -86,22 +89,24 @@ const TransactionsPrintAction: React.FC<Props> = ({ columns, data, itemUuid }) =
 
   return (
     <>
-      <ComboButton label="Print">
-        <MenuItem
-          label={t('printStockCard', 'Print Stock Card')}
-          renderIcon={(props) => <Printer size={24} {...props} />}
-          iconDescription="Print Stock Card"
-          onClick={handleStockcardClick}
-          disabled={isStockItemLoading || isStockCardLoading}
-        />
-        <MenuItem
-          label={t('printBinCard', 'Print Bin Card')}
-          renderIcon={(props) => <Printer size={24} {...props} />}
-          iconDescription="Print Bin Card"
-          onClick={handleBincardClick}
-          disabled={isStockItemLoading}
-        />
-      </ComboButton>
+      {enablePrintButton && (
+        <ComboButton label="Print">
+          <MenuItem
+            label={t('printStockCard', 'Print Stock Card')}
+            renderIcon={(props) => <Printer size={24} {...props} />}
+            iconDescription="Print Stock Card"
+            onClick={handleStockcardClick}
+            disabled={isStockItemLoading || isStockCardLoading}
+          />
+          <MenuItem
+            label={t('printBinCard', 'Print Bin Card')}
+            renderIcon={(props) => <Printer size={24} {...props} />}
+            iconDescription="Print Bin Card"
+            onClick={handleBincardClick}
+            disabled={isStockItemLoading}
+          />
+        </ComboButton>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds the following configurability:

- Adding the enablePrintButton configuration to control the visibility of the print button in the stock management UI.
- Allowing administrators to enable or disable the stock transactions print button using a configurable property.


## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/41e81f5a-323e-48b2-88a9-93d049cd22dc


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-4278
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
