### PR TITLE
(fix) O3-4446: Removing Misplaced '0' in Stock Operations Table

### DIFF
--- a/src/stock-operations/stock-operations-table.component.tsx
+++ b/src/stock-operations/stock-operations-table.component.tsx
@@ -309,7 +309,7 @@ const StockOperations: React.FC<StockOperationsTableProps> = () => {
                 </Tile>
               </div>
             ) : null}
-            {filterApplied && isLoading && (
+            {Boolean(filterApplied && isLoading) && (
               <div className={styles.rowLoadingContainer}>
                 <InlineLoading description={t('loading', 'Loading...')} />
               </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR was addressing the issue of a misplaced '0' in the Stock Operations table UI as seen in the screenshot below
<img width="1440" alt="Screenshot 2025-02-12 at 19 40 42" src="https://github.com/user-attachments/assets/cd6ba4d3-cd11-4211-9f4c-2ae0c383eed6" />


## Screenshots
<img width="1440" alt="Screenshot 2025-02-12 at 21 10 08" src="https://github.com/user-attachments/assets/5337772b-bfae-4b72-a4a1-3019a25592c8" />


## Related Issue
https://openmrs.atlassian.net/browse/O3-4446

## Other
<!-- Anything not covered above -->
