### PR TITLE
(fix) O3-4503: One items below min and above max on initial install

### DIFF
--- a/src/stock-home/stock-home-metrics.tsx
+++ b/src/stock-home/stock-home-metrics.tsx
@@ -71,8 +71,8 @@ const StockManagementMetrics: React.FC = (filter: StockOperationFilter) => {
           headerLabel={t('highestServiceVolume', 'Out of Stock ')}
           view="items"
           outofstockCount={{
-            itemsbelowmin: ['0'],
-            itemsabovemax: ['0'],
+            itemsbelowmin: [],
+            itemsabovemax: [],
           }}
         />
         <MetricsCard


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When the stock management module is first installed, the home page incorrectly displays “1 Items Below Min” and “1 Items Above Max,” even though no configuration or usage data exists yet. This PR fixes the issue by initializing those arrays as empty, removing the misleading alerts and ensuring a more accurate placeholder until the backend functionality is fully implemented.

## Screenshots
<img width="1440" alt="Screenshot 2025-03-05 at 18 36 21" src="https://github.com/user-attachments/assets/e63e73e9-a893-4a07-9cf3-99be41f1733d" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-4503

## Other
<!-- Anything not covered above -->
