### PR TITLE
feat: O3-4626-Prevent Duplicate Batch Numbers in Opening and Receipt Stock Operations

### DIFF
--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -28,6 +28,7 @@ import BatchNoSelector from '../batch-no-selector/batch-no-selector.component';
 
 import styles from './stock-items-addition-row.scss';
 import { useStockItemBatchInformationHook } from '../../stock-items/add-stock-item/batch-information/batch-information.resource';
+import UniqueBatchNoEntryInput from '../batch-no-selector/unique-batch-no-entry-input.component';
 
 interface StockItemsAdditionRowProps {
   canEdit?: boolean;
@@ -182,15 +183,11 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                 <div className={styles.cellContent}>
                   {requiresActualBatchInformation &&
                     (canEdit || (canUpdateBatchInformation && row?.permission?.canUpdateBatchInformation)) && (
-                      <TextInput
-                        size="sm"
-                        maxLength={50}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                          setValue(`stockItems.${index}.batchNo`, e.target.value)
-                        }
+                      <UniqueBatchNoEntryInput
+                        onValueChange={(val) => setValue(`stockItems.${index}.batchNo`, val)}
                         defaultValue={row.batchNo}
-                        invalidText=""
-                        invalid={errors?.stockItems?.[index]?.batchNo}
+                        error={errors?.stockItems?.[index]?.batchNo?.message}
+                        stockItemUuid={row.stockItemUuid}
                       />
                     )}
                   {requiresBatchUuid && !requiresActualBatchInformation && canEdit && (

--- a/src/stock-operations/batch-no-selector/unique-batch-no-entry-input.component.tsx
+++ b/src/stock-operations/batch-no-selector/unique-batch-no-entry-input.component.tsx
@@ -1,0 +1,54 @@
+import { TextInput } from '@carbon/react';
+import React, { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { useStockItemBatchNos } from './batch-no-selector.resource';
+import { TextInputSkeleton } from '@carbon/react';
+
+type UniqueBatchNoEntryInputProps = {
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  error?: string;
+  stockItemUuid: string;
+};
+const UniqueBatchNoEntryInput: React.FC<UniqueBatchNoEntryInputProps> = ({
+  defaultValue,
+  onValueChange,
+  error,
+  stockItemUuid,
+}) => {
+  const { isLoading, stockItemBatchNos } = useStockItemBatchNos(stockItemUuid);
+  const [value, setValue] = useState(defaultValue);
+  const [_error, setError] = useState<string>();
+
+  const batchNoAlreadyUsed = useMemo(
+    () => stockItemBatchNos?.findIndex((batchNo) => batchNo.batchNo === value) !== -1,
+    [stockItemBatchNos, value],
+  );
+
+  useEffect(() => {
+    if (defaultValue) setValue(defaultValue);
+  }, [defaultValue]);
+
+  useEffect(() => {
+    if (batchNoAlreadyUsed) {
+      setError('Batch number already used');
+    } else {
+      setError(undefined);
+      onValueChange?.(value);
+    }
+  }, [value, onValueChange, batchNoAlreadyUsed, setError]);
+
+  if (isLoading) return <TextInputSkeleton />;
+
+  return (
+    <TextInput
+      size="sm"
+      maxLength={50}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+      value={value}
+      invalidText={_error ?? error}
+      invalid={_error ?? error}
+    />
+  );
+};
+
+export default UniqueBatchNoEntryInput;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
**Use Case Story**:

_Imagine this scenario_:

- Morning: Person A starts their shift and enters an opening receipt stock operation for "item X" with the batch number "BatchA."

- Afternoon: Person B takes over the shift and continues with receipt stock entries. Unaware of Person A's earlier entry, they attempt to input another record for "item X" with the same batch number "BatchA."

- Without validation in place, this results in duplicate entries, which could cause confusion in inventory tracking, mismanagement of stock levels, and reporting inaccuracies.

- To avoid this, the system should perform real-time checks to detect if "BatchA" has already been used for "item X." If a duplicate is detected, the system must display a clear error message, This will ensure that no duplicates are entered and stock data remains accurate.

Acceptance Criteria:

- The system must validate batch numbers for each item during receipt and opening stock operations and prevent duplicates.

- If a user enters a batch number already used for the same item, an error message should be displayed, and the entry should not be saved.


## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/a5969881-5c4e-4132-b5d3-7aa19083e222

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4626

## Other
<!-- Anything not covered above -->
