### PR TITLE
(feat) Stock operations table UI enhancements

### DIFF
--- a/src/core/components/overlay/overlay.scss
+++ b/src/core/components/overlay/overlay.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .desktopOverlay {
   position: fixed;

--- a/src/core/components/privilages-component/privilages.scss
+++ b/src/core/components/privilages-component/privilages.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/type';
 @use '@carbon/layout';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .content {
   @include type.type-style('heading-compact-02');

--- a/src/core/components/table/table.scss
+++ b/src/core/components/table/table.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/type';
 @use '@carbon/layout';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .widgetContainer {
   background-color: $ui-background;

--- a/src/core/components/tabs/vertical-tabs.scss
+++ b/src/core/components/tabs/vertical-tabs.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .heading {
   @include type.type-style('productive-heading-02');

--- a/src/stock-items/add-stock-item/stock-item-details/stock-item-details.scss
+++ b/src/stock-items/add-stock-item/stock-item-details/stock-item-details.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .section {
   margin: layout.$spacing-03;

--- a/src/stock-items/stock-items-table.scss
+++ b/src/stock-items/stock-items-table.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/styles/scss/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .headerBtnContainer {
   background-color: $ui-background;
@@ -74,6 +74,8 @@
 .filterContainer {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  margin-bottom: layout.$spacing-05;
 }
 
 .dateAlign {
@@ -82,17 +84,12 @@
 }
 
 .filtersAlign {
-  padding-bottom: layout.$spacing-03;
+  margin-bottom: layout.$spacing-03;
+  min-width: auto;
+  width: auto;
 
   :global(.cds--list-box__menu) {
     min-width: 15rem;
     z-index: 1;
   }
-}
-
-.filterContainer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: layout.$spacing-05;
 }

--- a/src/stock-items/stock-items.component.tsx
+++ b/src/stock-items/stock-items.component.tsx
@@ -3,7 +3,7 @@ import StockItemsTableComponent from './stock-items-table.component';
 
 const StockItems = () => {
   return (
-    <div style={{ margin: '5px' }}>
+    <div style={{ margin: '1rem' }}>
       <StockItemsTableComponent />
     </div>
   );

--- a/src/stock-locations/stock-locations.component.tsx
+++ b/src/stock-locations/stock-locations.component.tsx
@@ -3,7 +3,7 @@ import StockLocationsItems from './stock-locations-table.component';
 
 function StockLocations() {
   return (
-    <div style={{ margin: '5px' }}>
+    <div style={{ margin: '1rem' }}>
       <StockLocationsItems />
     </div>
   );

--- a/src/stock-management-header/stock-management-header.scss
+++ b/src/stock-management-header/stock-management-header.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .header {
   @include type.type-style('body-compact-02');

--- a/src/stock-operations/add-stock-operation/stock-operations-expanded-row/stock-operation-expanded-row.scss
+++ b/src/stock-operations/add-stock-operation/stock-operations-expanded-row/stock-operation-expanded-row.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .textHeading {
   font-weight: bold;

--- a/src/stock-operations/stock-operations-filters.component.tsx
+++ b/src/stock-operations/stock-operations-filters.component.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { getStockOperationTypes, useConcept } from '../stock-lookups/stock-lookups.resource';
 import { DropdownSkeleton, MultiSelect } from '@carbon/react';
+import { getStockOperationTypes, useConcept } from '../stock-lookups/stock-lookups.resource';
 import { StockFilters } from '../constants';
 import { StockOperationStatusTypes } from '../core/api/types/stockOperation/StockOperationStatus';
 import styles from '../stock-items/stock-items-table.scss';
 
 interface StockOperationFiltersProps {
   conceptUuid?: string;
-  onFilterChange: (selectedItems: any[], filterType: string) => void;
   filterName: string;
+  onFilterChange: (selectedItems: any[], filterType: string) => void;
 }
 
 const StockOperationsFilters: React.FC<StockOperationFiltersProps> = ({ conceptUuid, onFilterChange, filterName }) => {
@@ -58,11 +58,12 @@ const StockOperationsFilters: React.FC<StockOperationFiltersProps> = ({ conceptU
 
   return (
     <MultiSelect
+      autoAlign
       className={styles.filtersAlign}
+      disabled={!dataItems.length}
       id="multiSelect"
       label={filterName}
-      size="md"
-      labelInline={true}
+      labelInline
       items={dataItems}
       itemToString={(item) => (item ? item.display : 'Not Set')}
       onChange={({ selectedItems }) => {
@@ -74,7 +75,6 @@ const StockOperationsFilters: React.FC<StockOperationFiltersProps> = ({ conceptU
         }
       }}
       placeholder={`Filter by ${filterName}`}
-      style={{ minWidth: 'auto', width: 'auto' }}
     />
   );
 };

--- a/src/stock-operations/stock-operations-table.scss
+++ b/src/stock-operations/stock-operations-table.scss
@@ -1,7 +1,7 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '@carbon/colors';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .tileContainer {
   background-color: $ui-02;
@@ -34,23 +34,20 @@
 .toolbarContent {
   display: flex;
   align-items: center;
+  height: layout.$spacing-09;
+  margin-top: layout.$spacing-05;
 }
 
-.filterContainer {
+.container {
   display: flex;
   align-items: center;
-}
-
-.dateAlign {
-  padding-top: layout.$spacing-03;
-  height: 100%;
+  justify-content: space-between;
 }
 
 .filterContainer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: layout.$spacing-05;
 }
 
 .rowLoadingContainer {
@@ -95,4 +92,16 @@
 
 .relatedTransactionHeader {
   color: colors.$green-50;
+}
+
+.toolbarMenuAction {
+  max-width: none;
+}
+
+.dataTableSkeleton {
+  margin-top: layout.$spacing-09;
+}
+
+.datePicker {
+  margin-bottom: layout.$spacing-05;
 }

--- a/src/stock-operations/stock-operations.component.tsx
+++ b/src/stock-operations/stock-operations.component.tsx
@@ -3,7 +3,7 @@ import StockOperations from './stock-operations-table.component';
 
 function StockOperationsComponent() {
   return (
-    <div style={{ margin: '5px' }}>
+    <div style={{ margin: '1rem' }}>
       <StockOperations />
     </div>
   );

--- a/src/stock-reports/report-list/stock-reports.scss
+++ b/src/stock-reports/report-list/stock-reports.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/type';
 @use '@carbon/layout';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .content {
   @include type.type-style('heading-compact-02');

--- a/src/stock-sources/add-stock-sources/add-stock-sources.scss
+++ b/src/stock-sources/add-stock-sources/add-stock-sources.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .section {
   margin: layout.$spacing-03;

--- a/src/stock-sources/delete-stock-modal.scss
+++ b/src/stock-sources/delete-stock-modal.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .bodyText {
   @include type.type-style('body-long-01');

--- a/src/stock-sources/stock-sources.component.tsx
+++ b/src/stock-sources/stock-sources.component.tsx
@@ -3,7 +3,7 @@ import StockSourcesItems from './stock-sources-items-table.component';
 
 function StockSources() {
   return (
-    <div style={{ margin: '5px' }}>
+    <div style={{ margin: '1rem' }}>
       <StockSourcesItems />
     </div>
   );

--- a/src/stock-user-role-scopes/delete-stock-user-scope-modal.scss
+++ b/src/stock-user-role-scopes/delete-stock-user-scope-modal.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .bodyText {
   @include type.type-style('body-long-01');

--- a/src/stock-user-role-scopes/stock-user-role-scopes.component.tsx
+++ b/src/stock-user-role-scopes/stock-user-role-scopes.component.tsx
@@ -3,7 +3,7 @@ import StockUserRoleScopesItems from './stock-user-role-scopes-items-table.compo
 
 function StockUserScopes() {
   return (
-    <div style={{ margin: '5px' }}>
+    <div style={{ margin: '1rem' }}>
       <StockUserRoleScopesItems />
     </div>
   );

--- a/src/stock-user-role-scopes/stock-user-role-scopes.scss
+++ b/src/stock-user-role-scopes/stock-user-role-scopes.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '~@openmrs/esm-styleguide/src/vars' as *;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .content {
   @include type.type-style('heading-compact-02');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Applies several UI enhancements to the stock operations table, including:
- Adding labels to the range datepicker
- Improving the toolbar layout and styling
- Cleaning up duplicate styles

Other broader changes include:

- Reorganizing imports to match conventions
- Improving code formatting
- Removing the `~` prefix from @openmrs/esm-styleguide imports

## Screenshots

### Before

![CleanShot 2025-05-14 at 16 03 15@2x](https://github.com/user-attachments/assets/f9e29fc6-f2a1-4030-8bed-c10fa6bdd1e2)

### After

![CleanShot 2025-05-14 at 14 33 50@2x](https://github.com/user-attachments/assets/7dbedb77-5a29-497a-aab2-96a10dabf6bf)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
