### PR TITLE
(fix) Remove stock metrics loading spinner to prevent layout shift

### DIFF
--- a/src/stock-home/stock-home-metrics.component.tsx
+++ b/src/stock-home/stock-home-metrics.component.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { InlineLoading } from '@carbon/react';
 import { ErrorState } from '@openmrs/esm-framework';
-import { useDisposalList } from './useDisposalList';
 import { ResourceRepresentation } from '../core/api/api';
-import { useStockInventoryItems } from './stock-home-inventory-items.resource';
+import { useDisposalList } from './useDisposalList';
 import { useStockInventory } from './stock-home-inventory-expiry.resource';
+import { useStockInventoryItems } from './stock-home-inventory-items.resource';
 import { type StockOperationFilter } from '../stock-operations/stock-operations.resource';
 import useStockList from './useStockList';
 import MetricsCard from '../core/components/card/metrics-card-component';
@@ -13,8 +12,8 @@ import styles from './stock-home.scss';
 
 const StockManagementMetrics: React.FC = (filter: StockOperationFilter) => {
   const { t } = useTranslation();
-  const { stockList: allStocks, isLoading, error } = useStockList();
-  const { items: expiryItems, isLoading: inventoryLoading } = useStockInventory();
+  const { stockList: allStocks, error } = useStockList();
+  const { items: expiryItems } = useStockInventory();
   const { items: stockItems } = useStockInventoryItems();
 
   const currentDate = new Date();
@@ -39,10 +38,6 @@ const StockManagementMetrics: React.FC = (filter: StockOperationFilter) => {
     v: ResourceRepresentation.Full,
     totalCount: true,
   });
-
-  if (isLoading) {
-    return <InlineLoading role="progressbar" description={t('loading', 'Loading...')} />;
-  }
 
   if (error) {
     return <ErrorState headerTitle={t('errorStockMetric', 'Error fetching stock metrics')} error={error} />;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Removes the loading spinner from stock metrics component to eliminate layout shift when data loads. This improves the user experience by maintaining a stable layout during data fetching.

## Screenshots

### Before
![CleanShot 2025-05-16 at 14 40 53@2x](https://github.com/user-attachments/assets/ba7e04c5-ffb4-4d7a-b8c9-d7fb34de66ce)

### After
![CleanShot 2025-05-16 at 14 34 00@2x](https://github.com/user-attachments/assets/a8813732-2ec9-4c58-98b3-54c186de9864)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
