### PR TITLE
03-4798-Add Packaging unit of measure in Batch number selector dropdown items display

### DIFF
--- a/src/stock-operations/stock-operations-forms/input-components/batch-no-selector.component.tsx
+++ b/src/stock-operations/stock-operations-forms/input-components/batch-no-selector.component.tsx
@@ -30,6 +30,7 @@ const BatchNoSelector: React.FC<BatchNoSelectorProps> = ({ stockItemUuid, error,
         return {
           ...item,
           quantity: matchingBatch.quantity ?? '',
+          quantityUoM: matchingBatch.quantityUoM,
         };
       }
       return item;
@@ -54,7 +55,9 @@ const BatchNoSelector: React.FC<BatchNoSelectorProps> = ({ stockItemUuid, error,
       items={filteredBatches || []}
       itemToString={(s: StockBatchDTO) =>
         s?.batchNo
-          ? `${s?.batchNo} | Qty: ${s?.quantity ?? 'Unknown'} | Expiry: ${formatForDatePicker(s.expiration)}`
+          ? `${s?.batchNo} | Qty: ${s?.quantity ?? 'Unknown'} ${
+              (s as StockBatchDTO & { quantityUoM: string })?.quantityUoM
+            } | Expiry: ${formatForDatePicker(s.expiration)}`
           : ''
       }
       name={'stockBatchUuid'}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Sections with drop downs under commodity transactions do not show the packaging UoM. In the picture below, is the quantity of 30 in tablets, boxes, packets? Potential errors in stock transactions

![9f3563c7-72d2-4e56-a3f2-85f95e0b4fb3](https://github.com/user-attachments/assets/71838e21-5050-41d6-8893-8092f04bcb2d)

Added quantity uom to sort that
## Screenshots
<!-- Required if you are making UI changes. -->

<img width="1440" alt="Screenshot 2025-06-12 at 08 10 37" src="https://github.com/user-attachments/assets/78ed3d36-8c04-4e70-8917-e9214b62a814" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4798
## Other
<!-- Anything not covered above -->
