### PR TITLE
(feat) O3-4822:Separate stock adjustment and stock take reasons

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -30,6 +30,11 @@ export const configSchema = {
     _description: 'UUID for the stock adjustment reasons',
     _default: '47f0825e-8648-47c2-b847-d3197ed6bb72',
   },
+  stockTakeReasonUUID: {
+    _type: Type.ConceptUuid,
+    _description: 'UUID for the stock take reasons',
+    _default: '47f0825e-8648-47c2-b847-d3197ed6bb72',
+  },
   stockSourceTypeUUID: {
     _type: Type.ConceptUuid,
     _description: 'UUID for the stock source types',
@@ -85,4 +90,5 @@ export type ConfigObject = {
     alt: string;
     name: string;
   };
+  stockTakeReasonUUID;
 };

--- a/src/stock-operations/stock-operations-forms/input-components/stock-operation-reason-selector.component.tsx
+++ b/src/stock-operations/stock-operations-forms/input-components/stock-operation-reason-selector.component.tsx
@@ -6,15 +6,23 @@ import { useTranslation } from 'react-i18next';
 import { type ConfigObject } from '../../../config-schema';
 import { type Concept } from '../../../core/api/types/concept/Concept';
 import { useConcept } from '../../../stock-lookups/stock-lookups.resource';
+import { OperationType } from '../../../core/api/types/stockOperation/StockOperationType';
 
-const StockOperationReasonSelector = () => {
-  const { stockAdjustmentReasonUUID } = useConfig<ConfigObject>();
+type StockOperationReasonSelectorProps = {
+  stockOperationType: string;
+};
+
+const StockOperationReasonSelector: React.FC<StockOperationReasonSelectorProps> = ({ stockOperationType }) => {
+  const { stockAdjustmentReasonUUID, stockTakeReasonUUID } = useConfig<ConfigObject>();
+  const operationReason =
+    stockOperationType === OperationType.STOCK_TAKE_OPERATION_TYPE ? stockTakeReasonUUID : stockAdjustmentReasonUUID;
+
   const form = useFormContext<{ reasonUuid: string }>();
   const {
     isLoading,
     error,
     items: { answers: reasons },
-  } = useConcept(stockAdjustmentReasonUUID);
+  } = useConcept(operationReason);
   const { t } = useTranslation();
   if (isLoading) return <SelectSkeleton role="progressbar" />;
 

--- a/src/stock-operations/stock-operations-forms/input-components/stock-operation-reason-selector.test.tsx
+++ b/src/stock-operations/stock-operations-forms/input-components/stock-operation-reason-selector.test.tsx
@@ -64,7 +64,7 @@ describe('StockoperationReasonSelector', () => {
       error: null,
     });
 
-    render(<StockOperationReasonSelector />);
+    render(<StockOperationReasonSelector stockOperationType={''} />);
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
@@ -77,7 +77,7 @@ describe('StockoperationReasonSelector', () => {
       error: new Error(errorMessahe),
     });
 
-    render(<StockOperationReasonSelector />);
+    render(<StockOperationReasonSelector stockOperationType={''} />);
 
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText(errorMessahe)).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe('StockoperationReasonSelector', () => {
   it('renders ComboBox with reasons', async () => {
     const user = userEvent.setup();
 
-    render(<StockOperationReasonSelector />);
+    render(<StockOperationReasonSelector stockOperationType={''} />);
 
     const combobox = screen.getByRole('combobox');
     await user.click(combobox);

--- a/src/stock-operations/stock-operations-forms/steps/base-operation-details-form-step.tsx
+++ b/src/stock-operations/stock-operations-forms/steps/base-operation-details-form-step.tsx
@@ -223,7 +223,7 @@ const BaseOperationDetailsFormStep: FC<BaseOperationDetailsFormStepProps> = ({
       <UsersSelector />
       {operationTypePermision.requiresStockAdjustmentReason && (
         <Column>
-          <StockOperationReasonSelector />
+          <StockOperationReasonSelector stockOperationType={stockOperationType?.operationType} />
         </Column>
       )}
       <Column>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the system uses a single list of operation reasons for both stock adjustments and stock take, without distinguishing between the two types of operations.  There is a need to separate and clearly define the reasons specific to stock adjustments and those specific to stock take activities.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4822
## Other
<!-- Anything not covered above -->
