### PR TITLE
(feat) O3-4823: Change metrics labels to ‘Understocked’ and ‘Overstocked’

### DIFF
--- a/src/core/components/card/metrics-card-component.tsx
+++ b/src/core/components/card/metrics-card-component.tsx
@@ -51,8 +51,8 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
         )}
         {!isEmpty(outOfStockCount) && (
           <div className={styles.countGrid}>
-            <span className={styles.belowMinLabel}>{t('itemsUnderstocked', 'Items understocked')}</span>
-            <span className={styles.aboveMaxLabel}>{t('itemsOverstocked', 'Items overstocked')}</span>
+            <span className={styles.belowMinLabel}>{t('understockedItems', 'Understocked items')}</span>
+            <span className={styles.aboveMaxLabel}>{t('overstockedItems', 'Overstocked items')}</span>
             <p className={styles.belowMinValue}>{outOfStockCount.itemsBelowMin?.length}</p>
             <p className={styles.aboveMaxValue}>{outOfStockCount.itemsAboveMax?.length}</p>
           </div>

--- a/src/core/components/card/metrics-card-component.tsx
+++ b/src/core/components/card/metrics-card-component.tsx
@@ -51,8 +51,8 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
         )}
         {!isEmpty(outOfStockCount) && (
           <div className={styles.countGrid}>
-            <span className={styles.belowMinLabel}>{t('understocked', 'Understocked')}</span>
-            <span className={styles.aboveMaxLabel}>{t('overstocked', 'Overstocked')}</span>
+            <span className={styles.belowMinLabel}>{t('itemsUnderstocked', 'Items understocked')}</span>
+            <span className={styles.aboveMaxLabel}>{t('itemsOverstocked', 'Items overstocked')}</span>
             <p className={styles.belowMinValue}>{outOfStockCount.itemsBelowMin?.length}</p>
             <p className={styles.aboveMaxValue}>{outOfStockCount.itemsAboveMax?.length}</p>
           </div>

--- a/src/core/components/card/metrics-card-component.tsx
+++ b/src/core/components/card/metrics-card-component.tsx
@@ -51,8 +51,8 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
         )}
         {!isEmpty(outOfStockCount) && (
           <div className={styles.countGrid}>
-            <span className={styles.belowMinLabel}>{t('itemsBelowMin', 'Items Below Min')}</span>
-            <span className={styles.aboveMaxLabel}>{t('itemsAboveMax', 'Items Above Max')}</span>
+            <span className={styles.belowMinLabel}>{t('understocked', 'Understocked')}</span>
+            <span className={styles.aboveMaxLabel}>{t('overstocked', 'Overstocked')}</span>
             <p className={styles.belowMinValue}>{outOfStockCount.itemsBelowMin?.length}</p>
             <p className={styles.aboveMaxValue}>{outOfStockCount.itemsAboveMax?.length}</p>
           </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Update the terminology used in the stock management metrics section to use more descriptive and business-friendly labels:

Change "Below Max" → "Understocked"

Change "Above Max" → "Overstocked"

## Screenshots
<!-- Required if you are making UI changes. -->
![fmfmfmf](https://github.com/user-attachments/assets/5fb132b7-2bd4-406c-a7bb-8ea62e95e7e5)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4823
https://thepalladiumgroup.atlassian.net/browse/KHP3-8091

## Other
<!-- Anything not covered above -->
