### PR TITLE
(fix) O3 4831: Display packaging UoM in commodity transaction batch selector

### DIFF
--- a/src/core/api/types/stockItem/StockBatchDTO.ts
+++ b/src/core/api/types/stockItem/StockBatchDTO.ts
@@ -6,3 +6,12 @@ export interface StockBatchDTO {
   quantity: string;
   voided: boolean;
 }
+
+export interface StockBatchWithUoM extends StockBatchDTO {
+  quantityUoM?: string;
+  quantityFactor?: string;
+  quantityUoMUuid?: string;
+  partyName?: string;
+  locationUuid?: string;
+  partyUuid?: string;
+}

--- a/src/stock-operations/stock-operations-forms/input-components/batch-no-selector.component.tsx
+++ b/src/stock-operations/stock-operations-forms/input-components/batch-no-selector.component.tsx
@@ -53,35 +53,38 @@ const BatchNoSelector: React.FC<BatchNoSelectorProps> = ({ stockItemUuid, error,
     [filteredBatches, initialValue],
   );
 
-  const formatQuantityDisplay = useCallback((batch: StockBatchWithUoM): string => {
-    if (batch.quantity === undefined) return 'Unknown';
+  const formatQuantityDisplay = useCallback(
+    (batch: StockBatchWithUoM): string => {
+      if (batch.quantity === undefined) return t('unknown', 'Unknown');
 
-    const quantity = typeof batch.quantity === 'string' ? parseFloat(batch.quantity) : batch.quantity;
+      const quantity = typeof batch.quantity === 'string' ? parseFloat(batch.quantity) : batch.quantity;
 
-    if (isNaN(quantity)) return 'Unknown';
+      if (isNaN(quantity)) return t('unknown', 'Unknown');
 
-    const baseQuantity = quantity.toString();
+      const baseQuantity = quantity.toString();
 
-    if (!batch.quantityUoM) return baseQuantity;
+      if (!batch.quantityUoM) return baseQuantity;
 
-    const withUnit = `${baseQuantity} ${batch.quantityUoM}`;
+      const withUnit = `${baseQuantity} ${batch.quantityUoM}`;
 
-    if (!batch.quantityFactor) return withUnit;
+      if (!batch.quantityFactor) return withUnit;
 
-    const factor = parseFloat(batch.quantityFactor);
-    return !isNaN(factor) && factor > 1 ? `${withUnit} (${factor} units each)` : withUnit;
-  }, []);
+      const factor = parseFloat(batch.quantityFactor);
+      return !isNaN(factor) && factor > 1 ? `${withUnit} (${factor} units each)` : withUnit;
+    },
+    [t],
+  );
 
   const itemToString = useCallback(
     (batch: StockBatchWithUoM | null): string => {
       if (!batch?.batchNo) return '';
 
       const quantityDisplay = formatQuantityDisplay(batch);
-      const expiryDate = batch.expiration ? formatForDatePicker(batch.expiration) : 'No expiry';
+      const expiryDate = batch.expiration ? formatForDatePicker(batch.expiration) : t('noExpiry', 'No expiry');
 
       return `${batch.batchNo} | Qty: ${quantityDisplay} | Expiry: ${expiryDate}`;
     },
-    [formatQuantityDisplay],
+    [formatQuantityDisplay, t],
   );
 
   const handleChange = useCallback(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The batch selector dropdowns in commodity transactions display quantities without packaging unit of measure (UoM) information, creating critical ambiguity that leads to stock transaction errors.

```Current Display: Batch001 | Qty: 30 | Expiry: 2024-12-31```

**User Question**: "Is this 30 individual tablets, 30 boxes, or 30 packets?"


**What is expected**
Batch selector should display complete packaging hierarchy:
 ```
Batch001 | Qty: 30 boxes (100 tablets each) | Expiry: 2024-12-31
Batch002 | Qty: 50 bottles (60 capsules each) | Expiry: 2025-01-15
Batch003 | Qty: 25 strips (10 tablets each) | Expiry: 2024-11-30
```

## Screenshots
<!-- Required if you are making UI changes. -->
![UOM](https://github.com/user-attachments/assets/620581a2-8aa9-45a2-8740-a1c35ee656e3)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://thepalladiumgroup.atlassian.net/browse/KHP3-8049
https://openmrs.atlassian.net/browse/O3-4831

## Other
<!-- Anything not covered above -->
