### PR TITLE
(chore): Require @openmrs/esm-framework 8.x in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "7.x",
+    "@openmrs/esm-framework": "8.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4380,7 +4380,7 @@ __metadata:
     yup: "npm:^1.2.0"
     zod: "npm:^3.22.2"
   peerDependencies:
-    "@openmrs/esm-framework": 7.x
+    "@openmrs/esm-framework": 8.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the peerDependencies for all packages to require @openmrs/esm-framework 8.x which corresponds to the [latest version of Core](https://github.com/openmrs/openmrs-esm-core/releases/tag/v8.0.0)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
