### PR TITLE
(test) Add ResizeObserver mock and update Carbon to align with framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-stock-management-app/issues"
   },
   "dependencies": {
-    "@carbon/react": "^1.83.0",
+    "@carbon/react": "^1.92.1",
     "@hookform/resolvers": "^3.3.0",
     "@playwright/test": "^1.52.0",
     "dotenv": "^16.4.5",

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -3,3 +3,10 @@ import '@testing-library/jest-dom';
 // https://github.com/jsdom/jsdom/issues/1695
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 window.HTMLElement.prototype.scrollIntoView = function () {};
+
+// Mock ResizeObserver for Carbon components
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,12 +1482,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.0, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.27.0
-  resolution: "@babel/runtime@npm:7.27.0"
-  dependencies:
-    regenerator-runtime: "npm:^0.14.0"
-  checksum: 10/e6966e03b695feb4c0ac0856a4355231c2580bf9ebd0298f47739f85c0ea658679dd84409daf26378d42c86c1cbe7e33feab709b14e784254b6c441d91606465
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.0, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.27.3, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.28.4
+  resolution: "@babel/runtime@npm:7.28.4"
+  checksum: 10/6c9a70452322ea80b3c9b2a412bcf60771819213a67576c8cec41e88a95bb7bf01fc983754cda35dc19603eef52df22203ccbf7777b9d6316932f9fb77c25163
   languageName: node
   linkType: hard
 
@@ -1545,11 +1543,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/charts@npm:^1.23.8":
-  version: 1.23.9
-  resolution: "@carbon/charts@npm:1.23.9"
+"@carbon/charts@npm:^1.23.8, @carbon/charts@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "@carbon/charts@npm:1.27.0"
   dependencies:
-    "@carbon/colors": "npm:^11.31.0"
+    "@carbon/colors": "npm:^11.37.0"
     "@carbon/utils-position": "npm:^1.3.0"
     "@ibm/telemetry-js": "npm:^1.9.1"
     "@types/d3": "npm:^7.4.3"
@@ -1563,93 +1561,93 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     topojson-client: "npm:^3.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/c783ef4ae5c09d307c9acc0149749623edf2360eb78bbc49eb3b854e46017d5750165648e5dd6ac4fb8a26eb72ee56d5e759bb82f8304b65083abdaa4848a3b6
+  checksum: 10/c23c924a9053b8528e9a1e4fe0f01fd58b4232aefa15c8c8a52c4cce9dcc45e2f3ed7de91d0821b884a1eeee534b7965d24839e4a733275a9fd5d7023b544830
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.31.0, @carbon/colors@npm:^11.33.0":
-  version: 11.33.0
-  resolution: "@carbon/colors@npm:11.33.0"
+"@carbon/colors@npm:^11.37.0, @carbon/colors@npm:^11.41.0":
+  version: 11.41.0
+  resolution: "@carbon/colors@npm:11.41.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/b98ff3978fb0a8474d6c1b4f76f0667ad9b043613473cfe179f4c420823452027d5398faa751cbad0766b8b66cfd7506b6c24b10796dc323b16d92fcd22560be
+  checksum: 10/ed463bf457320c9402018c0a0db82b2f84481533f8253fcee9b81540a862c604db15a00b1a020bbdf846b371979e2e9e872071190280f2f11b6c021968965809
   languageName: node
   linkType: hard
 
-"@carbon/feature-flags@npm:^0.26.0":
-  version: 0.26.0
-  resolution: "@carbon/feature-flags@npm:0.26.0"
+"@carbon/feature-flags@npm:^0.31.0":
+  version: 0.31.0
+  resolution: "@carbon/feature-flags@npm:0.31.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/7115d79358330ec7a27b2c502f6bf6b95ce19c530dae19f73b57ca491cc237a3981939d1fa9436e7093e76a19e638a62c85ae7c2fbdaf46de93fcf6255200553
+  checksum: 10/fe7ec8f7f338535811c2852606b6b2ac19382857f2881867137d1cc530df6fa0a8b33bf6c367ec5c88899421a851cbe34425479d4b229ec20c8c838313c0700d
   languageName: node
   linkType: hard
 
-"@carbon/grid@npm:^11.36.0":
-  version: 11.36.0
-  resolution: "@carbon/grid@npm:11.36.0"
+"@carbon/grid@npm:^11.44.0":
+  version: 11.44.0
+  resolution: "@carbon/grid@npm:11.44.0"
   dependencies:
-    "@carbon/layout": "npm:^11.34.0"
+    "@carbon/layout": "npm:^11.42.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/33faa1634d7924ff53c4e9116c4aeed5d1736e684573522c237a5857d1034da258d6ddbaef02b8764cfd5fd55f13a6ffea2f615b3da0ba558d8b20cec4f821fb
+  checksum: 10/9eabcf297191be3d2278de64e8ae760d6086d5cc84139bf4a5ba061489ab16cfe47400ea7d94df2ce49fa544d9bef26c8d0c67aabe564ff079fc3532bfb07ee3
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.59.0":
-  version: 10.59.0
-  resolution: "@carbon/icon-helpers@npm:10.59.0"
+"@carbon/icon-helpers@npm:^10.67.0":
+  version: 10.67.0
+  resolution: "@carbon/icon-helpers@npm:10.67.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/2a9a5671f7814bf89132f997e63eb5ecac06f094baa1b9c8bc55d113d3903e18af4cefa9e7d0390d9bede8b8e06f7b89fe60c9bd740c20121971bfe48a5cdae5
+  checksum: 10/84f0bbb2bd6e8a55771f37b559e6342df2931354d452ffe9619d197b2767969770a13bba6d5e3ec46f54d302e7854a70c6ebb4aa398d5ae2d8ae8b0633d17c65
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.60.0":
-  version: 11.60.0
-  resolution: "@carbon/icons-react@npm:11.60.0"
+"@carbon/icons-react@npm:^11.68.0":
+  version: 11.68.0
+  resolution: "@carbon/icons-react@npm:11.68.0"
   dependencies:
-    "@carbon/icon-helpers": "npm:^10.59.0"
+    "@carbon/icon-helpers": "npm:^10.67.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     react: ">=16"
-  checksum: 10/3952f3495126d035264a3e70620008985a732579b1176f9c89e9100ac0ccf726fcfe670664eabcbca038fc44ab9a026a8ad98bbbbc31248821297deb54dd57f5
+  checksum: 10/d78507722af5b00e43881186d63de5b08c3eab2bb86964b26ce7e06ce1740fd632327537dbe3805cadfe1729a024723887ce1b96cedf57cc42eb1e257a551a40
   languageName: node
   linkType: hard
 
-"@carbon/layout@npm:^11.34.0":
-  version: 11.34.0
-  resolution: "@carbon/layout@npm:11.34.0"
+"@carbon/layout@npm:^11.42.0":
+  version: 11.42.0
+  resolution: "@carbon/layout@npm:11.42.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/19c0382a6580fa5a1a07e2a85bf2aed53efe6fc5f60441f40407242caaab2a14f2ba234447af7d273336e0249f3bd7e75a91b0e296d6223790b41a654395b00f
+  checksum: 10/bf038bfab3d9e0a161a69c7ac48afc47bd96332eef90f4d33eb2cc325427bd4020bfcbef4c8301c5f39583959796145473143b4dd78702091285f247e7262f05
   languageName: node
   linkType: hard
 
-"@carbon/motion@npm:^11.28.0":
-  version: 11.28.0
-  resolution: "@carbon/motion@npm:11.28.0"
+"@carbon/motion@npm:^11.36.0":
+  version: 11.36.0
+  resolution: "@carbon/motion@npm:11.36.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/a4933f9689d4d4ae450ac4fe809b8d407af4b23164a2a0563f1c3ade6011c28b4ce8dc65bcffe9fc10f349b3395e86f596220ea9468cda80e0bd43c60c052586
+  checksum: 10/b20f42cff7950bc3e1e0add0ce31330574c6a4b21b6c8597156c1a31007654bdbe63439f019f07dc59a2ed60e70c7c7215c0f78cd4de06bada0777e8d2e3bff8
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.83.0":
-  version: 1.83.0
-  resolution: "@carbon/react@npm:1.83.0"
+"@carbon/react@npm:^1.83.0, @carbon/react@npm:^1.92.1":
+  version: 1.92.1
+  resolution: "@carbon/react@npm:1.92.1"
   dependencies:
-    "@babel/runtime": "npm:^7.24.7"
-    "@carbon/feature-flags": "npm:^0.26.0"
-    "@carbon/icons-react": "npm:^11.60.0"
-    "@carbon/layout": "npm:^11.34.0"
-    "@carbon/styles": "npm:^1.82.0"
-    "@carbon/utilities": "npm:^0.6.0"
+    "@babel/runtime": "npm:^7.27.3"
+    "@carbon/feature-flags": "npm:^0.31.0"
+    "@carbon/icons-react": "npm:^11.68.0"
+    "@carbon/layout": "npm:^11.42.0"
+    "@carbon/styles": "npm:^1.91.0"
+    "@carbon/utilities": "npm:^0.10.0"
     "@floating-ui/react": "npm:^0.27.4"
     "@ibm/telemetry-js": "npm:^1.5.0"
     classnames: "npm:2.5.1"
     copy-to-clipboard: "npm:^3.3.1"
-    downshift: "npm:9.0.8"
+    downshift: "npm:9.0.10"
     es-toolkit: "npm:^1.27.0"
     flatpickr: "npm:4.6.13"
     invariant: "npm:^2.2.3"
@@ -1662,70 +1660,71 @@ __metadata:
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
     react-is: ^16.13.1 || ^17.0.2 || ^18.3.1 || ^19.0.0
     sass: ^1.33.0
-  checksum: 10/8396b673af9ebb0a53d46fbb3226fc93ff48af75748d5b1bb6d87bce93bef835fb8e609f0f9003b4b31eec7b28aa14ea4a4ef32893c498b831d1b13fffa4bacc
+  checksum: 10/ab8e657beaf65dc54c2108c922116a1b01b95531fa74fb48f571115536ad972b1bf0e12c1ae8977b2635b09ac5d2b1dde44aa4f31b016d9edeb3520f7693bb80
   languageName: node
   linkType: hard
 
-"@carbon/styles@npm:^1.82.0":
-  version: 1.82.0
-  resolution: "@carbon/styles@npm:1.82.0"
+"@carbon/styles@npm:^1.91.0":
+  version: 1.91.0
+  resolution: "@carbon/styles@npm:1.91.0"
   dependencies:
-    "@carbon/colors": "npm:^11.33.0"
-    "@carbon/feature-flags": "npm:^0.26.0"
-    "@carbon/grid": "npm:^11.36.0"
-    "@carbon/layout": "npm:^11.34.0"
-    "@carbon/motion": "npm:^11.28.0"
-    "@carbon/themes": "npm:^11.53.0"
-    "@carbon/type": "npm:^11.40.0"
+    "@carbon/colors": "npm:^11.41.0"
+    "@carbon/feature-flags": "npm:^0.31.0"
+    "@carbon/grid": "npm:^11.44.0"
+    "@carbon/layout": "npm:^11.42.0"
+    "@carbon/motion": "npm:^11.36.0"
+    "@carbon/themes": "npm:^11.61.0"
+    "@carbon/type": "npm:^11.48.0"
     "@ibm/plex": "npm:6.0.0-next.6"
-    "@ibm/plex-mono": "npm:0.0.3-alpha.0"
-    "@ibm/plex-sans": "npm:0.0.3-alpha.0"
-    "@ibm/plex-sans-arabic": "npm:0.0.3-alpha.0"
-    "@ibm/plex-sans-devanagari": "npm:0.0.3-alpha.0"
+    "@ibm/plex-mono": "npm:1.1.0"
+    "@ibm/plex-sans": "npm:1.1.0"
+    "@ibm/plex-sans-arabic": "npm:1.1.0"
+    "@ibm/plex-sans-devanagari": "npm:1.1.0"
     "@ibm/plex-sans-hebrew": "npm:0.0.3-alpha.0"
     "@ibm/plex-sans-thai": "npm:0.0.3-alpha.0"
-    "@ibm/plex-sans-thai-looped": "npm:0.0.3-alpha.0"
-    "@ibm/plex-serif": "npm:0.0.3-alpha.0"
+    "@ibm/plex-sans-thai-looped": "npm:1.1.0"
+    "@ibm/plex-serif": "npm:1.1.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
   peerDependencies:
     sass: ^1.33.0
   peerDependenciesMeta:
     sass:
       optional: true
-  checksum: 10/4b6bfce1191152c4bd14866933b2d9d27784fc7c97747b800b6b283258a53deab4ece1257f62e78e77ce6d4027941326e9632263e2c18a8cd76956adc29d1f07
+  checksum: 10/49fb502711270c8d12a1fd797d3eca4b4e350921eab575a7f322bb54b264822f34a53c8b40c3f1e9c2c47c57e617616d70052f34f27b544c536ce349edd7239c
   languageName: node
   linkType: hard
 
-"@carbon/themes@npm:^11.53.0":
-  version: 11.53.0
-  resolution: "@carbon/themes@npm:11.53.0"
+"@carbon/themes@npm:^11.61.0":
+  version: 11.61.0
+  resolution: "@carbon/themes@npm:11.61.0"
   dependencies:
-    "@carbon/colors": "npm:^11.33.0"
-    "@carbon/layout": "npm:^11.34.0"
-    "@carbon/type": "npm:^11.40.0"
+    "@carbon/colors": "npm:^11.41.0"
+    "@carbon/layout": "npm:^11.42.0"
+    "@carbon/type": "npm:^11.48.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     color: "npm:^4.0.0"
-  checksum: 10/af2e5e430e7e76028cc05e3a56072da0ceacc65e862df381a95aa9ae89480eee21beaf14a6aeca53badcf4e3e51e5248a4355d17e03f5ee376c9ab3654207329
+  checksum: 10/7cab96b13db9a021a96226be4713b7024ebc1abe170c7083b772dc025766f025bcdb8d14acb46daa0abde49e9b4577441c621c8acba00cabcd0a16e9edd4acbd
   languageName: node
   linkType: hard
 
-"@carbon/type@npm:^11.40.0":
-  version: 11.40.0
-  resolution: "@carbon/type@npm:11.40.0"
+"@carbon/type@npm:^11.48.0":
+  version: 11.48.0
+  resolution: "@carbon/type@npm:11.48.0"
   dependencies:
-    "@carbon/grid": "npm:^11.36.0"
-    "@carbon/layout": "npm:^11.34.0"
+    "@carbon/grid": "npm:^11.44.0"
+    "@carbon/layout": "npm:^11.42.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/36e16539bc5fec1aae20c48f22683a9761f44cfbd23544a35b2743651414695b35a4af6236b15bb3408f16626470e5ae5a1df00acc688e83a212fba1dc4bd882
+  checksum: 10/f42deb53de6b61c53ba07ef8ff5a9890879f89bf9e84128822f44b1f2419bd173d4259bb8dc207b16d879941d226bf06da68132410c17b5205b2b770d6cb8b4f
   languageName: node
   linkType: hard
 
-"@carbon/utilities@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@carbon/utilities@npm:0.6.0"
+"@carbon/utilities@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@carbon/utilities@npm:0.10.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.6.1"
-  checksum: 10/2217d67fc897b40a9cf7d4b7ab55e1a252cbf11530d9754acfd347f081daed9dd6c2a87d0a8f81d1b3b8050fc46ff6a63443a0df334a076c4b85573b4e84c5c4
+    "@internationalized/number": "npm:^3.6.1"
+  checksum: 10/b07b72f945b9996879c63c6793fbd7aa96f9cac5fb6f415345bec79e9aa65f3df822bc4e2e8e12681c0c28a231c2cda6c4a8293c4c0f2e5fd76266d4ff924f28
   languageName: node
   linkType: hard
 
@@ -2441,24 +2440,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex-mono@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-mono@npm:0.0.3-alpha.0"
-  checksum: 10/fbdfb70762dead35bd12fd69344133f3290bd4ede4fd3607f6949e80e3c516190e772afc5f8ba060426911bf1b89744f02e7b0fdd25cca818086f3ce312fcad4
+"@ibm/plex-mono@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-mono@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/dc9deecac43c7db641e472cb350b883042d8833f103fb0b2ebbb435750908a77c7f60d57ab90da9b3cc05f8c026ba0104506231f3905ec125ae644d923cbe813
   languageName: node
   linkType: hard
 
-"@ibm/plex-sans-arabic@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-sans-arabic@npm:0.0.3-alpha.0"
-  checksum: 10/c390dd9788a36f4cb2abb2fcf63deb2a3c8b9e7aa8a7e6263ff6484b2fe99044258e2daeb36e7c0b0eeaea17e4128a8ce567208458f851ee6b05ec8c54f84edb
+"@ibm/plex-sans-arabic@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-sans-arabic@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/69bfd4d9f80ecfeb5365a5be84453e877275e8c1b8cbdefcf7ba15d01157face0e6ed524a3b8f2b993e4de85abbd53811b5eaf6ecd6b31391e5e8d7d1c268356
   languageName: node
   linkType: hard
 
-"@ibm/plex-sans-devanagari@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-sans-devanagari@npm:0.0.3-alpha.0"
-  checksum: 10/ef3cd967100210a822bea7b36c5ac54f915a319d5e23fa1175ea63d0405c826023f241d54b4f7beb5928603fbe01a5bae22839dad6922330bb84921eb289d193
+"@ibm/plex-sans-devanagari@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-sans-devanagari@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/a6b05ad8c4d556cb439d5b51c94ebb8152c1a26cb9e86f6b3a95808b6a2c4c21fab29a96296ac4af7bde8d46c8360e8bea7f082054a088f96eb3949a77241e93
   languageName: node
   linkType: hard
 
@@ -2469,10 +2474,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex-sans-thai-looped@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-sans-thai-looped@npm:0.0.3-alpha.0"
-  checksum: 10/11272b1353611fed07788a870793ca6f45c644f47faa99880d5278552a7acd85b0696ca02336b7aa8e29bf5d6353538d322149cb8b6b2e65985c38f0af6359fe
+"@ibm/plex-sans-thai-looped@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-sans-thai-looped@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/aafa09baf6f159acb735097d726b2c4cac2ba780cfeddbc755ce2fb1583b9a717a78eb7600e99524537e0b9a8355d4c5ee576de21ced379149c00b7e6b1771f7
   languageName: node
   linkType: hard
 
@@ -2483,17 +2490,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/plex-sans@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-sans@npm:0.0.3-alpha.0"
-  checksum: 10/5b0b0521dbeb7c32eb13a932b53baef0013b96d5d39547b35c69a991707a3f75cec37383c9f239229fdedfb91fda8c8005f25fdddcb900937d6de7dbd456175a
+"@ibm/plex-sans@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-sans@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/065c244f5f741d60423bd714554365b323d551e8227861244d51e03c05bcd1808caa041f4909284120b3ab2bf4a5d4d0a54469013af4701b741875cf29a77b2d
   languageName: node
   linkType: hard
 
-"@ibm/plex-serif@npm:0.0.3-alpha.0":
-  version: 0.0.3-alpha.0
-  resolution: "@ibm/plex-serif@npm:0.0.3-alpha.0"
-  checksum: 10/462dcf33937f50f5a0ecf320f1d930c612e92293aa40dda08c05f6630d8795e4233023bb4f8ed3d340d2dbbd82a4b7ec5ae5e511f4260b16ff9ade6f481e48e8
+"@ibm/plex-serif@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@ibm/plex-serif@npm:1.1.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.6.1"
+  checksum: 10/30b175c8d8e7ea6ca54e5735b9241c47fb570b86ceeb7890111370a58cd1bafc9de92c8aea500dc509e5caa569b180c522de84cf2eefd139e06e3b1209e4573f
   languageName: node
   linkType: hard
 
@@ -4038,9 +4049,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-api@npm:8.0.1-pre.3360"
+"@openmrs/esm-api@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-api@npm:8.0.1-pre.3370"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -4048,18 +4059,18 @@ __metadata:
     "@openmrs/esm-error-handling": 6.x
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-navigation": 6.x
-  checksum: 10/0d045b6f9c6c3edb6f81aac9c1299047c5c792e634bb053e04fff40fdf0f729d2b957362bbc8bea64e6bc2e4b7e7125c8cf833aa2eec0bcdb84ef99ab0934222
+  checksum: 10/6292e29830a1c726b4cdaa639d0941109633eaea99aec88bbc1f8b4b707a5fe156a1bfeaabcce1f1a83afd61b3ea2a380688cee8e7f8f29582f87c4669f94b76
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-app-shell@npm:8.0.1-pre.3360"
+"@openmrs/esm-app-shell@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-app-shell@npm:8.0.1-pre.3370"
   dependencies:
-    "@carbon/react": "npm:^1.83.0"
+    "@carbon/react": "npm:^1.92.1"
     "@internationalized/date": "npm:^3.8.0"
-    "@openmrs/esm-framework": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-styleguide": "npm:8.0.1-pre.3360"
+    "@openmrs/esm-framework": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-styleguide": "npm:8.0.1-pre.3370"
     dayjs: "npm:^1.11.13"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -4068,8 +4079,8 @@ __metadata:
     import-map-overrides: "npm:^3.0.0"
     lodash-es: "npm:4.17.21"
     mini-css-extract-plugin: "npm:^2.9.1"
-    react: "npm:^18.1.0"
-    react-dom: "npm:^18.1.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
     react-i18next: "npm:^11.18.6"
     react-router-dom: "npm:^6.3.0"
     rxjs: "npm:^6.5.3"
@@ -4084,13 +4095,13 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/6a9416491e10fcfcb7c5cadb7da9b4f89c40c4c5cba544dbd774cdda2c1338a4d3b2af2f947b648ce389cf0b4e2f484e60c70a6ec74019f5ea69620c53913275
+  checksum: 10/bdb087b41b1000cc42555f7c0a0c2055595d874947534e3689f73ce0b13fcb081744719e13b045cb088b1dc5a8dca0b4ae757ef81bc6358f5402a41699336a51
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-config@npm:8.0.1-pre.3360"
+"@openmrs/esm-config@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-config@npm:8.0.1-pre.3370"
   dependencies:
     ramda: "npm:^0.30.1"
   peerDependencies:
@@ -4098,33 +4109,33 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/bf82eddebba53e21554461da7b70a65ee70aa3b2398096fe0d8a289d6542defef6cb95385466c7f69b79f09152ec631b5b2d445c414e694cc0aede03f4e00782
+  checksum: 10/dfa54e241463294d2be30833faeb8fbbcfd3bb565e40e81e6b9b9d7d2e8c5d31e27b6582c22fe627f7c4f3d208823028d7c667aaabf9ef39a25873acb04f01ad
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-context@npm:8.0.1-pre.3360"
+"@openmrs/esm-context@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-context@npm:8.0.1-pre.3370"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
-  checksum: 10/cfbf0b0f82da90070cfd6aa0eb2300d9695dca31b6313169182b5599deda2e5c5f8cf8483bf18599848f77b864ec733c3534a19db9e9fbbe9683163d4fb7d8fa
+  checksum: 10/dbb68955edf5407178c2d538f0139965c112eb9590589303530191a4a6b5bfd17f0f6ad3461f9f9fd2268f107913426cb56bd19a82b5899ec90f7432e7434b35
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-dynamic-loading@npm:8.0.1-pre.3360"
+"@openmrs/esm-dynamic-loading@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-dynamic-loading@npm:8.0.1-pre.3370"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-translations": 6.x
-  checksum: 10/6393a74e35feeb098ad6a1f7d891c73084233ec2af38efa532c0121efaf193b509b42e3c8001eb471f02aa1c044e7a5d1e541cee81db6647f22fcb6bf6798aa7
+  checksum: 10/80c11b2839565c03b7e234400088bcfe0d906e6f1370bc5dd0d7d02bb025e09e37f3e747455760b040d51bbba304e41c30ca70388d9ea2d8c2467e8f5efb0397
   languageName: node
   linkType: hard
 
-"@openmrs/esm-emr-api@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-emr-api@npm:8.0.1-pre.3360"
+"@openmrs/esm-emr-api@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-emr-api@npm:8.0.1-pre.3370"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -4132,22 +4143,22 @@ __metadata:
     "@openmrs/esm-api": 6.x
     "@openmrs/esm-offline": 6.x
     "@openmrs/esm-state": 6.x
-  checksum: 10/79427a9c24119bdfe312000e4aa8f6c94a287dc8ad660cf3e0e6ea241592e02d5cbc55e604edb24d27cbde25fc6c6c591cb1373684ece3b0261aa94bbcefc9de
+  checksum: 10/4234a14da672b999e7d2b2c03571cb635367b91083b6b96e61ba3bc46c13278dc4abbf9e3c47a13782fcf13a4015b42c88191046ec6573003c670157a3949823
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-error-handling@npm:8.0.1-pre.3360"
+"@openmrs/esm-error-handling@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-error-handling@npm:8.0.1-pre.3370"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
-  checksum: 10/5b0ade8c3dcc4a4ca427a3928e15b691d9fc2bf5af2fc736450fde858abb7748ee7a7277707cd68611c13f0eac7c2981c8959293b07ef059761b16c0ca500582
+  checksum: 10/477e2e4a392cbc83c071152d202464e67f64da3c5716c9f638bbbd1f0a1f2e15d305baf8ffa2bb230c2aa34cb3bf43be2131bf8d978668d08eee5358a011ad16
   languageName: node
   linkType: hard
 
-"@openmrs/esm-expression-evaluator@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-expression-evaluator@npm:8.0.1-pre.3360"
+"@openmrs/esm-expression-evaluator@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-expression-evaluator@npm:8.0.1-pre.3370"
   dependencies:
     "@jsep-plugin/arrow": "npm:^1.0.6"
     "@jsep-plugin/new": "npm:^1.0.4"
@@ -4156,13 +4167,13 @@ __metadata:
     "@jsep-plugin/template": "npm:^1.0.5"
     "@jsep-plugin/ternary": "npm:^1.1.4"
     jsep: "npm:^1.4.0"
-  checksum: 10/d1ec78298aeb46afabe9f1db3a1ecd1bf2509febfa0d4e50f4f9d5009c393c8480d743a08f79c4960151ecf3c7ab231845f1e331c27d6d0e0bda7c04fd516064
+  checksum: 10/c1023f2370e02a3c975decc47abcca23813337a42ee646820fa02a4d91b07c94abbaa47e04a584a6d1e7a146b0175a02102c71388d6e07ae0fa9fd3ad6f1be22
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-extensions@npm:8.0.1-pre.3360"
+"@openmrs/esm-extensions@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-extensions@npm:8.0.1-pre.3370"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -4173,43 +4184,43 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/5cb661a2c4a756ab9b358fac2057cf580f6e982ccaa4955fe80084097d36f7d2c9e208f06e2dff43ffc7c08c2064856eb093c2561b48f09f066557cc7f262be8
+  checksum: 10/a44a20802e2d70ad0b088bdd00b4e9de4f58ad82fb4a757e204851068cb31a68f314a9d48f884397f8a6ccd3deff5a0439445123091618fd94a92f2e7f4d03df
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-feature-flags@npm:8.0.1-pre.3360"
+"@openmrs/esm-feature-flags@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-feature-flags@npm:8.0.1-pre.3370"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     single-spa: 6.x
-  checksum: 10/d76a6b0f912933d198f172f1ce6b8373aeb096e14c16ec450ab7820d7f40f105158e4a619dea72a084c08abfed3896660870759cd58792acf4ab39149318c056
+  checksum: 10/05d7e98238256d61873f16b41593db7ee74b036245db5999480afbcae4e81948ee4349af5de7000b4fcc39432a2f863d45d3ff0328bcacff0ef5d06ffd9743cd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:8.0.1-pre.3360, @openmrs/esm-framework@npm:next":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-framework@npm:8.0.1-pre.3360"
+"@openmrs/esm-framework@npm:8.0.1-pre.3370, @openmrs/esm-framework@npm:next":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-framework@npm:8.0.1-pre.3370"
   dependencies:
-    "@openmrs/esm-api": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-config": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-context": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-dynamic-loading": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-emr-api": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-error-handling": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-expression-evaluator": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-extensions": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-feature-flags": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-globals": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-navigation": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-offline": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-react-utils": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-routes": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-state": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-styleguide": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-translations": "npm:8.0.1-pre.3360"
-    "@openmrs/esm-utils": "npm:8.0.1-pre.3360"
+    "@openmrs/esm-api": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-config": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-context": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-dynamic-loading": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-emr-api": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-error-handling": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-expression-evaluator": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-extensions": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-feature-flags": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-globals": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-navigation": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-offline": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-react-utils": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-routes": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-state": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-styleguide": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-translations": "npm:8.0.1-pre.3370"
+    "@openmrs/esm-utils": "npm:8.0.1-pre.3370"
   peerDependencies:
     dayjs: 1.x
     i18next: 21.x
@@ -4219,35 +4230,35 @@ __metadata:
     rxjs: 6.x
     single-spa: 6.x
     swr: 2.x
-  checksum: 10/479fbdf70f5cb08f7f73ce691a1c29e45f8bcaed29ef2dc75048bbe5b129c50c8eb7171a87544f10c68e287ef1e931c76faf8aeff4ab6443274896be59e901f6
+  checksum: 10/baec8e65b5d07828822f1809d5577c0c1097eb5ae906bd3b0835e4ed5d4cb9b44be553c8683cbe229f3522aa030a7c5f0c5cd8a96b0787703c75ee86011229f5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-globals@npm:8.0.1-pre.3360"
+"@openmrs/esm-globals@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-globals@npm:8.0.1-pre.3370"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 6.x
-  checksum: 10/42cbe89ba758f28b4f1c44f9897340bd6930a0ce43cd31257a5f9878d3be5831f4715c5c82b32bd97d98bdc62bfabc75f9ec6715bd792c8492842e8020ae8201
+  checksum: 10/d3356f25b0e795558ccd1d5e0d8cceb3c044df854964ebaae9a9acaa7aef3e9791fada6df153fba86a0a685a2c9db5fdbb691a23b85a85a1d11f783e487c231e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-navigation@npm:8.0.1-pre.3360"
+"@openmrs/esm-navigation@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-navigation@npm:8.0.1-pre.3370"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 6.x
-  checksum: 10/4372a3f7b70f94736aba5733cd386e714f9e2d12155a8e045a10d5ec18b84501235b49c27f05d9ff1e7e6a8da9353ebaf13751bd306738dacb1bf4880fb1f748
+  checksum: 10/bc66c40b2274b67e6dabeff74b27171e34c569078708a7ebfac75cb77bfabede8287d13e02205428ba70b3a04d07ef3f9963179d35f92a68b262ba4046206585
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-offline@npm:8.0.1-pre.3360"
+"@openmrs/esm-offline@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-offline@npm:8.0.1-pre.3370"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -4258,13 +4269,13 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     rxjs: 6.x
-  checksum: 10/9356713a005b7c234ec2272617c9ccc9e7dd4e66329bbe164bf5e647d10595d10d6cf1e99720503ede867b9545a4a20ac2c0eaa81cd5afd6da62917161b74859
+  checksum: 10/ed6e383ebe5c3c9c3da224b4c96eb66ad2e8a184b6fb5a8828a1d9ad39b22abe8ea3fa02fe81293150dbf89741c869d09672b3c25da03f97eafa4727d50f324f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-react-utils@npm:8.0.1-pre.3360"
+"@openmrs/esm-react-utils@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-react-utils@npm:8.0.1-pre.3370"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.2"
@@ -4287,13 +4298,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/10a05867c055c893207f097b19b32acbf0592d03e16c3a209c5dbdd25164b770a8eac9f80cc9c55dfab0dc552ef8f658353795f091bb68ff9e60704fe2822d75
+  checksum: 10/0d4cf46e4dd1b8b9f5f2f3f66b50c470ad6b2d8211d565dc88ee0182c8cade6730758472fad954e2cbd1e0d9bad3c4ecd35294791c8c85b09ab2892fa9d95fa4
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-routes@npm:8.0.1-pre.3360"
+"@openmrs/esm-routes@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-routes@npm:8.0.1-pre.3370"
   peerDependencies:
     "@openmrs/esm-config": 6.x
     "@openmrs/esm-dynamic-loading": 6.x
@@ -4302,19 +4313,19 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/ffb210b7d7f3febb6ffacf76435ea088ac2bf105498bdab7efda989241453f0793cd8edb3e7fc8aaa9ce8d8f638dc9d816b8f7a19698f8d0b71c12ac0617fada
+  checksum: 10/709970a3f5af021052b807c5f5925819531f8e1b7e0296991e1fe09638d516f29d8812499d03f64abcc47139a821eb4dbd9d885861b2483ba0671ea8dd80c219
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-state@npm:8.0.1-pre.3360"
+"@openmrs/esm-state@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-state@npm:8.0.1-pre.3370"
   dependencies:
     zustand: "npm:^4.5.5"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
-  checksum: 10/355b370192db741eded0881c3a3e91e121efb8cb1f03d51c99d00038c4c902387a2dd062fcd268f9f4c6cffeb9f8534b9eec8266900bc4677ba5e758c6221da6
+  checksum: 10/ac45af6b3e096df12a81ec245f6e7b3514b5fecb6529daac79c03ce610317eeb0d9ebd20ce3e6b589141d53280f99e550a6793ba46fd9707f273b941a1aaa8cf
   languageName: node
   linkType: hard
 
@@ -4322,7 +4333,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-stock-management-app@workspace:."
   dependencies:
-    "@carbon/react": "npm:^1.83.0"
+    "@carbon/react": "npm:^1.92.1"
     "@hookform/resolvers": "npm:^3.3.0"
     "@openmrs/esm-framework": "npm:next"
     "@openmrs/esm-styleguide": "npm:next"
@@ -4390,7 +4401,43 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-styleguide@npm:8.0.1-pre.3360, @openmrs/esm-styleguide@npm:next":
+"@openmrs/esm-styleguide@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-styleguide@npm:8.0.1-pre.3370"
+  dependencies:
+    "@carbon/charts": "npm:^1.27.0"
+    "@carbon/react": "npm:^1.92.1"
+    "@internationalized/date": "npm:^3.8.0"
+    core-js-pure: "npm:^3.36.0"
+    d3: "npm:^7.8.0"
+    geopattern: "npm:^1.2.3"
+    lodash-es: "npm:^4.17.21"
+    react-aria-components: "npm:^1.7.1"
+    react-avatar: "npm:^5.0.3"
+  peerDependencies:
+    "@openmrs/esm-api": 6.x
+    "@openmrs/esm-config": 6.x
+    "@openmrs/esm-emr-api": 6.x
+    "@openmrs/esm-error-handling": 6.x
+    "@openmrs/esm-extensions": 6.x
+    "@openmrs/esm-globals": 6.x
+    "@openmrs/esm-navigation": 6.x
+    "@openmrs/esm-react-utils": 6.x
+    "@openmrs/esm-state": 6.x
+    "@openmrs/esm-translations": 6.x
+    "@openmrs/esm-utils": 6.x
+    dayjs: 1.x
+    i18next: 21.x
+    react: 18.x
+    react-dom: 18.x
+    react-i18next: 11.x
+    rxjs: 6.x
+    swr: 2.x
+  checksum: 10/e1dfee59c71977a97c0d6885d462a27093790e6595f496c1509c521da7e14ec5269cf43d697b83ebdbf5566c9a52bc684e0f5f193736cfdada1bb48892c4fc5b
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-styleguide@npm:next":
   version: 8.0.1-pre.3360
   resolution: "@openmrs/esm-styleguide@npm:8.0.1-pre.3360"
   dependencies:
@@ -4426,20 +4473,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-translations@npm:8.0.1-pre.3360"
+"@openmrs/esm-translations@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-translations@npm:8.0.1-pre.3370"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/e6c45961e4d6d28c8143e791df0d87099d821528b88ffa2b15f6672f2685d909a1f9a8e5190b98b33abd217e3fa787f146cd223ff52a66a15e0ebc8efcf1003b
+  checksum: 10/7a95fd0a9961075b5a6b48c51adbcab2313c064dbcf4d1e11dcd506acec686dc03df6fbe2cdf5d3baee7181af0d8fea5d58538f8447540e18632169976dbdc9a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/esm-utils@npm:8.0.1-pre.3360"
+"@openmrs/esm-utils@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/esm-utils@npm:8.0.1-pre.3370"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.7.3"
     "@internationalized/date": "npm:^3.8.0"
@@ -4451,13 +4498,13 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/a719f6fbb55bc45294e9edf3935d12ffa92414b133e98bc41f338fb8162018bd62f06ba14bb8e49687957cfb31b3e181b86e6172c813bdf37b46524673340f32
+  checksum: 10/92dfbc86492e0fbcd98ab3936b69ea12db5f442d8764d6d4f1d23e31c9e8188887eb15b880accd00c068a9c873fa5a3fce27f4d169b34c9efe2e2dec200b6870
   languageName: node
   linkType: hard
 
-"@openmrs/rspack-config@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/rspack-config@npm:8.0.1-pre.3360"
+"@openmrs/rspack-config@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/rspack-config@npm:8.0.1-pre.3370"
   dependencies:
     "@rspack/cli": "npm:^1.3.11"
     "@rspack/core": "npm:^1.3.11"
@@ -4473,13 +4520,13 @@ __metadata:
     ts-checker-rspack-plugin: "npm:^1.1.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-stats-plugin: "npm:^1.1.3"
-  checksum: 10/a4b7cf361f8dda58a83f2e3b3dce8b61b7e0e86a94066a67fa245618bc01d84573653c4d8530b5efa0c32f2ae23b5414bb653a14519cac6ae9745c7862bf9ef4
+  checksum: 10/0169983e2b0131e9da1b9a2eb715bb6b2a87e5c0fa199c72f2fd6cba499bf594acd15fc64b533a3c2f2b88554fc2527a2923361326e6d779ab6d81415adcc5a6
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:8.0.1-pre.3360":
-  version: 8.0.1-pre.3360
-  resolution: "@openmrs/webpack-config@npm:8.0.1-pre.3360"
+"@openmrs/webpack-config@npm:8.0.1-pre.3370":
+  version: 8.0.1-pre.3370
+  resolution: "@openmrs/webpack-config@npm:8.0.1-pre.3370"
   dependencies:
     "@swc/core": "npm:^1.11.29"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -4497,7 +4544,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.1.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/90208d403d697c049a9e13d43135238b973785a3b92d98d009b7a4a725c6c7114179cf4add3c9243c466f55f0128cc99ff0602d2de924a426b5e299a5f76a7df
+  checksum: 10/4981889ad25912f5b82b0486610ee63ede604ea275b22a1a4dc2311b258fc1e7895a596d917ddac0f7e99e11858a11cff772b5caedc83410f62b9bd7f5d64f52
   languageName: node
   linkType: hard
 
@@ -12074,9 +12121,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:9.0.8":
-  version: 9.0.8
-  resolution: "downshift@npm:9.0.8"
+"downshift@npm:9.0.10":
+  version: 9.0.10
+  resolution: "downshift@npm:9.0.10"
   dependencies:
     "@babel/runtime": "npm:^7.24.5"
     compute-scroll-into-view: "npm:^3.1.0"
@@ -12085,7 +12132,7 @@ __metadata:
     tslib: "npm:^2.6.2"
   peerDependencies:
     react: ">=16.12.0"
-  checksum: 10/9dc4577e780c54742ba4dde11f481f0d839f001b309200fbe4db112385b227ccd9cd2ef97d9e995379fa70249f0664a562240e415b9966f18c8a5cb7ce435f2c
+  checksum: 10/eb102d7eb18613c292b2b3e2b42ec70eb36ddda4d2bbcb544cc85932359b727ac566de4f3cf66123741d44fe16ac7639ff148abb5a9702e1f70bfab8ec1a3468
   languageName: node
   linkType: hard
 
@@ -19410,12 +19457,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 8.0.1-pre.3360
-  resolution: "openmrs@npm:8.0.1-pre.3360"
+  version: 8.0.1-pre.3370
+  resolution: "openmrs@npm:8.0.1-pre.3370"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:8.0.1-pre.3360"
-    "@openmrs/rspack-config": "npm:8.0.1-pre.3360"
-    "@openmrs/webpack-config": "npm:8.0.1-pre.3360"
+    "@openmrs/esm-app-shell": "npm:8.0.1-pre.3370"
+    "@openmrs/rspack-config": "npm:8.0.1-pre.3370"
+    "@openmrs/webpack-config": "npm:8.0.1-pre.3370"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@rspack/cli": "npm:^1.3.11"
     "@rspack/core": "npm:^1.3.11"
@@ -19460,7 +19507,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/c48b821aa100e969143a00cf53b533395de05e54e7ffc3ce9d2ce436f6fd8e594eedf0503144596aa309f43f1ef796ecd3aadf2443f8183057126754fa7356e6
+  checksum: 10/ccb9f00baab951127ee4916fb810153472d43a58bf37cc70ba830ead2d19b8ec6cf5eb494a39f6cb05058e74cc96f7a26344eed1eeac35a032d87eb709929760
   languageName: node
   linkType: hard
 
@@ -21106,15 +21153,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.1.0, react-dom@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.0"
+    scheduler: "npm:^0.23.2"
   peerDependencies:
-    react: ^18.2.0
-  checksum: 10/ca5e7762ec8c17a472a3605b6f111895c9f87ac7d43a610ab7024f68cd833d08eda0625ce02ec7178cc1f3c957cf0b9273cdc17aa2cd02da87544331c43b1d21
+    react: ^18.3.1
+  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
   languageName: node
   linkType: hard
 
@@ -21592,12 +21639,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.1.0, react@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:^18.2.0, react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/b9214a9bd79e99d08de55f8bef2b7fc8c39630be97c4e29d7be173d14a9a10670b5325e94485f74cd8bff4966ef3c78ee53c79a7b0b9b70cba20aa8973acc694
+  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
   languageName: node
   linkType: hard
 
@@ -21808,13 +21855,6 @@ __metadata:
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10/d493e9e118abef5b099c78170834f18540c4933cedf9bfabc32d3af94abfb59a7907bd7950259cbab0a929ebca7db77301e8024e5121e6482a82f78283dfd20c
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.14.0":
-  version: 0.14.1
-  resolution: "regenerator-runtime@npm:0.14.1"
-  checksum: 10/5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
   languageName: node
   linkType: hard
 
@@ -22749,12 +22789,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/0c4557aa37bafca44ff21dc0ea7c92e2dbcb298bc62eae92b29a39b029134f02fb23917d6ebc8b1fa536b4184934314c20d8864d156a9f6357f3398aaf7bfda8
+  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds a `ResizeObserver` global mock to fix Jest test failures when testing components that use Carbon Design System components (e.g., TextArea, DatePicker, DataTable) which require ResizeObserver in the browser environment.

Also updates `@carbon/react` from `^1.83.0` to `^1.92.1` to align with the version used in `@openmrs/esm-framework`. Additionally, this fixes the [failing](https://github.com/openmrs/openmrs-esm-stock-management/actions/workflows/update-openmrs-deps.yml) auto-update OpenMRS dependencies Github Action workflow.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
