### PR TITLE
(fix) O3-5562: Edit Items panel fields don't update when selecting a different stock item

### DIFF
--- a/src/stock-items/add-stock-item/add-stock-item.component.tsx
+++ b/src/stock-items/add-stock-item/add-stock-item.component.tsx
@@ -29,7 +29,12 @@ const AddEditStockItem: React.FC<AddStockItemProps> = ({ stockItem, closeWorkspa
     {
       name: t('stockItemDetails', 'Stock Item Details'),
       component: (
-        <StockItemDetails handleTabChange={handleTabChange} stockItem={stockItem} onCloseWorkspace={closeWorkspace} />
+        <StockItemDetails
+          key={stockItem?.uuid}
+          handleTabChange={handleTabChange}
+          stockItem={stockItem}
+          onCloseWorkspace={closeWorkspace}
+        />
       ),
     },
     {

--- a/src/stock-items/add-stock-item/add-stock-item.integration.test.tsx
+++ b/src/stock-items/add-stock-item/add-stock-item.integration.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { type StockItemDTO } from '../../core/api/types/stockItem/StockItem';
+import AddEditStockItem from './add-stock-item.component';
+
+// Mock the API-hitting child components so the integration test can focus on
+// the form-staleness behaviour without bringing in their dependencies.
+jest.mock('./drug-selector/drug-selector.component', () => () => <div data-testid="drug-selector" />);
+jest.mock('./concepts-selector/concepts-selector.component', () => () => <div data-testid="concepts-selector" />);
+jest.mock('./stock-item-category-selector/stock-item-category-selector.component', () => () => (
+  <div data-testid="stock-item-category-selector" />
+));
+jest.mock('./dispensing-unit-selector/dispensing-unit-selector.component', () => () => (
+  <div data-testid="dispensing-unit-selector" />
+));
+jest.mock('./preferred-vendor-selector/preferred-vendor-selector.component', () => () => (
+  <div data-testid="preferred-vendor-selector" />
+));
+jest.mock('./stock-item-units-edit/stock-item-units-edit.component', () => () => (
+  <div data-testid="stock-item-units-edit" />
+));
+
+// Other tabs are only mounted if the user navigates to them; the default tab
+// is Stock Item Details, which is what this test exercises. Mock them to keep
+// the test surface small.
+jest.mock('./packaging-units/packaging-units.component', () => () => <div data-testid="packaging-units" />);
+jest.mock('./transactions/transactions.component', () => () => <div data-testid="transactions" />);
+jest.mock('./batch-information/batch-information.component', () => () => <div data-testid="batch-information" />);
+jest.mock('./quantities/quantities.component', () => () => <div data-testid="quantities" />);
+jest.mock('./stock-item-rules/stock-item-rules.component', () => () => <div data-testid="stock-item-rules" />);
+jest.mock('./stock-item-references/stock-item-references.component', () => () => (
+  <div data-testid="stock-item-references" />
+));
+
+const baseItem: Partial<StockItemDTO> = {
+  isDrug: false,
+  hasExpiration: false,
+  commonName: '',
+  acronym: '',
+  conceptName: '',
+  expiryNotice: 0,
+  permission: { canView: true, canEdit: true } as StockItemDTO['permission'],
+};
+
+describe('AddEditStockItem (integration)', () => {
+  it('shows the newly selected stock item in the Stock Item Details form fields when stockItem changes', () => {
+    const itemA: StockItemDTO = {
+      ...(baseItem as StockItemDTO),
+      uuid: 'item-a',
+      commonName: 'Aspirin',
+      acronym: 'ASP',
+    };
+    const itemB: StockItemDTO = {
+      ...(baseItem as StockItemDTO),
+      uuid: 'item-b',
+      commonName: 'Paracetamol',
+      acronym: 'PCM',
+    };
+
+    const { rerender } = render(<AddEditStockItem stockItem={itemA} />);
+
+    expect(screen.getByDisplayValue('Aspirin')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('ASP')).toBeInTheDocument();
+
+    rerender(<AddEditStockItem stockItem={itemB} />);
+
+    expect(screen.getByDisplayValue('Paracetamol')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('PCM')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Aspirin')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('ASP')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Selecting a different stock item while the edit panel was open updated the workspace title but left the form fields showing the previously selected item's values.

Root cause: `StockItemDetails` initializes its form via `useForm({ defaultValues: stockItem ?? {} })`. React Hook Form only reads `defaultValues` on initial mount, so subsequent changes to the `stockItem` prop do not flow into the form fields.

Fix: add `key={stockItem?.uuid}` to `<StockItemDetails>` in `AddEditStockItem`. When the stock item changes, the key changes, React unmounts and remounts the component, and `useForm` re-initializes from the new `defaultValues`.

The other tabs in the same workspace (`PackagingUnits`, `Transactions`, etc.) do not have this pattern, since they either use SWR keyed on `stockItemUuid` or sync local state via a `useEffect`. So the fix is scoped to the one component that needs it.

## Screenshots

[Screencast from 2026-03-28 11-36-03.webm](https://github.com/user-attachments/assets/d5da55d8-835d-46ed-9491-dfcb6879766d)

## Related Issue

https://openmrs.atlassian.net/browse/O3-5562

## Other
