### PR TITLE
(fix) O3-5563: Require purchase price packaging unit when purchase price is set

### DIFF
--- a/src/stock-items/validationSchema.ts
+++ b/src/stock-items/validationSchema.ts
@@ -66,6 +66,15 @@ export const createStockItemDetailsSchema = (t: TFunction) =>
         message: t('expiryNoticeRequired', 'Expiry notice required'),
         path: ['expiryNotice'],
       },
+    )
+    .refine(
+      ({ purchasePrice, purchasePriceUoMUuid }) => {
+        return purchasePrice != null && purchasePrice > 0 ? !!purchasePriceUoMUuid : true;
+      },
+      {
+        message: t('purchasePriceUoMRequired', 'Purchase price packaging unit is required when purchase price is set'),
+        path: ['purchasePriceUoMUuid'],
+      },
     );
 
 export type StockItemFormData = z.infer<ReturnType<typeof createStockItemDetailsSchema>>;

--- a/translations/en.json
+++ b/translations/en.json
@@ -251,6 +251,7 @@
   "printStockCard": "Print Stock Card",
   "purchasePrice": "Purchase price",
   "purchasePricePackagingUnit": "Purchase price packaging unit",
+  "purchasePriceUoMRequired": "Purchase price packaging unit is required when purchase price is set",
   "quantities": "Quantities",
   "quantity": "Quantity",
   "quantityLabel": "Quantity:",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label. See existing PR titles for inspiration.
- [ ] My work conforms to the OpenMRS 3.0 Styleguide and design documentation.
- [ ] My work includes tests or is validated by existing tests.

## Summary

When editing a stock item, setting a purchase price without selecting a purchase price packaging unit would result in a misleading success toast being shown, while the purchase price value was silently not persisted. Reopening the item would confirm the value was never saved.

This fix adds frontend form validation to require the purchase price packaging unit whenever a purchase price is entered. An inline error message — "Purchase price packaging unit is required when purchase price is set" — is now shown on the field, and form submission is blocked until the packaging unit is selected.

## Screenshots

<!-- Add before/after screenshots or a short screen recording showing the validation error -->

## Related Issue

https://openmrs.atlassian.net/browse/O3-5563

## Other