### PR TITLE
(chore) Raise vitest testTimeout to 30s

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     clearMocks: true,
+    testTimeout: 30000,
     setupFiles: ['./tools/setup-tests.ts'],
     exclude: ['**/node_modules/**', '**/e2e/**', '**/dist/**'],
     server: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The default 5s per-test timeout fires on CI for the `StockItemsTable` 'renders initial state and UI elements correctly' test - a userEvent-heavy test that completes in well under a second locally but takes ~6s on GitHub Actions runners.

The local-vs-CI gap is vitest's per-test overhead (ESM resolution and SWC transforms) combined with slower CI hardware. The same pattern showed up across [openmrs-esm-patient-chart#3301](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3301) and was addressed there with the same global bump.

Raise `testTimeout` to 30s. Real hangs will still fail loudly; this only forgives slow-but-progressing tests.

The failing CI run that motivated this: https://github.com/openmrs/openmrs-esm-stock-management/actions/runs/25805834552/job/75808178552.

## Screenshots

N/A - tooling change only.

## Related Issue

N/A

## Other

All 112 tests pass locally under `yarn coverage`.