### PR TITLE
(fix) O3-5703: Prevent "Select source type" label from wrapping in stock sources toolbar

### DIFF
--- a/src/stock-sources/stock-sources-filter/stock-sources-filter.scss
+++ b/src/stock-sources/stock-sources-filter/stock-sources-filter.scss
@@ -5,6 +5,10 @@
     gap: 0;
   }
 
+  :global(.cds--label) {
+    white-space: nowrap;
+  }
+
   :global(.cds--list-box__menu-icon) {
     height: layout.$spacing-05;
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- The "Select source type" label in the Stock Sources toolbar was wrapping across multiple lines
- Added `white-space: nowrap` to the Carbon `.cds--label` class inside the filter component's scoped styles
- No logic or behaviour changes. CSS only fix

## Screenshots
<!-- Required if you are making UI changes. -->
### before

<img width="1658" height="275" alt="image" src="https://github.com/user-attachments/assets/072059b3-e7d6-4101-aa66-209b175ab16b" />


### after
<img width="1658" height="753" alt="image" src="https://github.com/user-attachments/assets/789c0981-9276-43e7-ab4e-b5f0b53f6025" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5703

## Other
<!-- Anything not covered above -->
