### PR TITLE
(chore) Add GitHub Actions workflow for opening release PRs

### DIFF
--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,80 @@
+name: 'Open Release PR'
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+        default: minor
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-release-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Fetch full history so tools that read tags/changelog (if any) work
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: 💾 Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: 📦 Install dependencies if cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Run release
+        id: release
+        run: |
+          yarn version ${{ inputs.release_type }}
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Run tests on release changes
+        run: yarn verify
+
+      - name: Create PR with release changes
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # branch name is unique per run
+          branch: "release/v${{ steps.release.outputs.version }}-${{ github.run_id }}"
+          commit-message: "chore(release): v${{ steps.release.outputs.version }}"
+          title: "(chore) Release v${{ steps.release.outputs.version }}"
+          body: |
+            This PR was created automatically via **workflow_dispatch**.
+
+            **Command ran**
+            ```
+            yarn version ${{ inputs.release_type }}
+            ```
+
+            Please review the changes (version bumps, changelog, etc.) and merge. :)
+          labels: |
+            release
+            automated-pr
+          delete-branch: true
+          author: "OpenMRS Bot <infrastructure@openmrs.org>"
+          committer: "OpenMRS Bot <infrastructure@openmrs.org>"
+          token: ${{ secrets.OMRS_BOT_GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This workflow automates the process of opening a pull request for a new release based on the specified release type (major, minor, or patch). It includes steps for checking out the repository, setting up Node.js, caching dependencies, running the release command, verifying changes, and creating the pull request.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
