### PR TITLE
(chore) O3-5863: Add @carbon/react to peerDependencies in openmrs-esm-stock-management

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-stock-management-app/issues"
   },
   "dependencies": {
+    "@carbon/icons-react": "^11.68.0",
     "@carbon/react": "^1.92.1",
     "@hookform/resolvers": "^3.3.0",
     "@playwright/test": "^1.52.0",
@@ -56,6 +57,8 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "11.x",
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "url": "https://github.com/openmrs/openmrs-esm-stock-management-app/issues"
   },
   "dependencies": {
-    "@carbon/react": "^1.92.1",
     "@hookform/resolvers": "^3.3.0",
     "@playwright/test": "^1.52.0",
     "dotenv": "^16.4.5",
@@ -56,6 +55,7 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",
@@ -65,6 +65,7 @@
     "swr": "2.x"
   },
   "devDependencies": {
+    "@carbon/react": "^1.92.1",
     "@openmrs/eslint-config": "^2.0.0",
     "@openmrs/esm-framework": "next",
     "@openmrs/esm-styleguide": "next",

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -4,6 +4,48 @@ import { cleanup } from '@testing-library/react';
 
 afterEach(cleanup);
 
+// Node >=22 defines an experimental localStorage/sessionStorage global that
+// resolves to undefined unless --localstorage-file is passed, shadowing jsdom's
+// storage. Restore the jsdom-backed instances (or an in-memory fallback).
+function installStorage(name: 'localStorage' | 'sessionStorage') {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+  if (descriptor && typeof descriptor.get === 'function') {
+    let store: Storage;
+    try {
+      store = (globalThis as { jsdom?: { window: Window } }).jsdom.window[name];
+    } catch {
+      store = undefined;
+    }
+    if (!store) {
+      const data = new Map<string, string>();
+      store = {
+        get length() {
+          return data.size;
+        },
+        key(index: number) {
+          return [...data.keys()][index] ?? null;
+        },
+        getItem(key: string) {
+          return data.has(key) ? data.get(key) : null;
+        },
+        setItem(key: string, value: string) {
+          data.set(key, String(value));
+        },
+        removeItem(key: string) {
+          data.delete(key);
+        },
+        clear() {
+          data.clear();
+        },
+      } as Storage;
+    }
+    Object.defineProperty(globalThis, name, { value: store, configurable: true, writable: true });
+  }
+}
+
+installStorage('localStorage');
+installStorage('sessionStorage');
+
 // https://github.com/jsdom/jsdom/issues/1695
 window.HTMLElement.prototype.scrollIntoView = function () {};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,6 +4612,7 @@ __metadata:
     yup: "npm:^1.2.0"
     zod: "npm:^3.22.2"
   peerDependencies:
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x

--- a/yarn.lock
+++ b/yarn.lock
@@ -4488,6 +4488,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-stock-management-app@workspace:."
   dependencies:
+    "@carbon/icons-react": "npm:^11.68.0"
     "@carbon/react": "npm:^1.92.1"
     "@hookform/resolvers": "npm:^3.3.0"
     "@openmrs/esm-framework": "npm:next"
@@ -4539,6 +4540,8 @@ __metadata:
     yup: "npm:^1.2.0"
     zod: "npm:^3.22.2"
   peerDependencies:
+    "@carbon/icons-react": 11.x
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Part of O3-5854 (share @carbon/react as Module Federation singletons across frontend module repos). The build tooling derives each app's Module Federation `shared` list from `peerDependencies`, so apps that omit `@carbon/react` bundle their own copies instead of using the shell-provided singleton.

This adds `@carbon/react` to `peerDependencies` with the shell's range (`1.x`) and moves it from `dependencies` to `devDependencies` (it remains installed locally for builds/tests).

Verified against a production build (`yarn build`):
- The eagerly-loaded entry bundle no longer contains any `@carbon/react` modules (1.67 MiB → 1.24 MiB).
- Carbon now emits as a single async shared-fallback chunk that only loads when no shell provider exists.

Existing tests pass.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5863

## Other
<!-- Anything not covered above -->
