### PR TITLE
(chore) Don't update eslint config

### DIFF
--- a/tools/update-openmrs-deps.mjs
+++ b/tools/update-openmrs-deps.mjs
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 
 try {
-  execSync(`yarn up --fixed '@openmrs/*@next' 'openmrs@next'`, {
+  execSync(`yarn up --fixed '@openmrs/esm-framework@next' '@openmrs/esm-styleguide@next' 'openmrs@next'`, {
     stdio: ['ignore', 'inherit', 'inherit'],
     windowsHide: true,
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Lists the `@openmrs` packages that actually track the `next` tag instead of globbing the whole scope.

The dependency auto-update workflow has failed on every run since `@openmrs/eslint-config` landed in the root devDependencies in #605. That package only publishes a `latest` tag, so resolving `@openmrs/*@next` fails and takes the whole `yarn up` down with it:

    YN0016: @openmrs/eslint-config@npm:next: Registry failed to return tag "next"
    Error while updating dependencies: Command failed: yarn up --fixed '@openmrs/*@next' 'openmrs@next'

`esm-framework` and `esm-styleguide` are the only `@openmrs` dependencies here that track `next`, so nothing loses coverage.

## Screenshots

## Related Issue

## Other

Same fix as openmrs/openmrs-esm-patient-management#2671, openmrs/openmrs-esm-form-builder#1286, openmrs/openmrs-esm-fast-data-entry-app#354, openmrs/openmrs-esm-billing-app#809 and openmrs/openmrs-esm-template-app#333. This was the last repo in the org still on the glob.
