### PR TITLE
(chore) Clean build outputs before bundle size comparison

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -32,3 +32,4 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           minimum-change-threshold: 10240 # 10 KB
           build-script: 'turbo run build --color --concurrency=5'
+          clean-script: 'clean'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "openmrs develop",
     "serve": "rspack serve --mode=development",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env analyze=true",
     "lint": "eslint src --fix --max-warnings=0",
     "prettier": "prettier --write \"src/**/*.{css,scss,ts,tsx}\" --list-different",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The compressed-size action builds the pull request and base revisions sequentially in the same workspace. When the base build is restored from the Turborepo cache, its build command is skipped and stale pull-request chunks can remain in `dist`. Those files are then incorrectly reported as removed, inflating the bundle-size change.

This adds the action-supported cleanup hook and a package-owned `clean` script scoped to the ignored `dist` directory. Cleanup therefore runs independently of whether the subsequent build is executed or restored from cache.

This follows the workflow fix validated in openmrs/openmrs-esm-patient-chart#3607.

## Screenshots

## Related Issue

Follow-up to openmrs/openmrs-esm-patient-chart#3607.

## Other