### PR TITLE
(fix) Use framework modal for stock locations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,3 +182,5 @@ export const transactionStockcardPrintPreviewModal = getSyncLifecycle(Transactio
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
+
+export const createLocationModal = getAsyncLifecycle(() => import('./stock-locations/add-location.modal'), options);

--- a/src/routes.json
+++ b/src/routes.json
@@ -197,6 +197,10 @@
     {
       "name": "transactions-print-stockcard-preview-modal",
       "component": "transactionStockcardPrintPreviewModal"
+    },
+    {
+      "name": "stock-create-location-modal",
+      "component": "createLocationModal"
     }
   ],
   "workspaces": [

--- a/src/stock-locations/add-location.modal.tsx
+++ b/src/stock-locations/add-location.modal.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { showSnackbar } from '@openmrs/esm-framework';
+import { saveLocation } from './stock-locations-table.resource';
+import { type locationData, type LocationMutator } from '../stock-items/types';
+import { extractErrorMessagesFromResponse } from '../constants';
+import LocationAdministrationForm from './location-admin-form.component';
+
+interface LocationFormProps {
+  close: () => void;
+  mutate: LocationMutator;
+}
+
+const NewLocationForm: React.FC<LocationFormProps> = ({ close, mutate }) => {
+  const { t } = useTranslation();
+  const headerTitle = t('addLocation', 'Create new Location');
+
+  const initialData: locationData = {
+    uuid: '',
+    name: '',
+    tags: [],
+  };
+
+  const handleCreateQuestion = useCallback(
+    (formData: locationData) => {
+      const { name, tags } = formData;
+
+      const locationbject = {
+        name,
+        tags,
+      };
+      saveLocation({ locationPayload: locationbject })
+        .then(() => {
+          showSnackbar({
+            title: t('locationCreatedTitle', 'Location created'),
+            kind: 'success',
+            isLowContrast: true,
+            subtitle: t('locationCreatedSuccessfully', 'Location {{locationName}} was created successfully.', {
+              locationName: name,
+            }),
+          });
+
+          mutate();
+        })
+        .catch((error) => {
+          const errorMessages = extractErrorMessagesFromResponse(error);
+          showSnackbar({
+            title: t('errorCreatingForm', 'Error creating location'),
+            kind: 'error',
+            isLowContrast: true,
+            subtitle: errorMessages.join(', '),
+          });
+        });
+      close();
+    },
+    [close, mutate, t],
+  );
+
+  return (
+    <LocationAdministrationForm
+      close={close}
+      handleCreateQuestion={handleCreateQuestion}
+      headerTitle={headerTitle}
+      initialData={initialData}
+    />
+  );
+};
+export default NewLocationForm;

--- a/src/stock-locations/add-location.test.tsx
+++ b/src/stock-locations/add-location.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+import { showSnackbar } from '@openmrs/esm-framework';
+import { saveLocation } from './stock-locations-table.resource';
+import NewLocationModal from './add-location.modal';
+
+vi.mock('./stock-locations-table.resource', () => ({
+  saveLocation: vi.fn(),
+  useLocationTags: () => ({ locationTagList: [] }),
+}));
+
+describe('create location modal', () => {
+  it('submits the form from the separate modal footer and refreshes after saving', async () => {
+    const user = userEvent.setup();
+    vi.mocked(saveLocation).mockResolvedValueOnce({ data: { name: 'Dispensary' } } as Awaited<
+      ReturnType<typeof saveLocation>
+    >);
+    const close = vi.fn(),
+      mutate = vi.fn();
+    render(<NewLocationModal close={close} mutate={mutate} />);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    await user.type(screen.getByRole('textbox', { name: 'Location name' }), 'Dispensary');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(saveLocation).toHaveBeenCalledWith({ locationPayload: { name: 'Dispensary', tags: [] } }),
+    );
+    await waitFor(() => expect(mutate).toHaveBeenCalledOnce());
+    expect(showSnackbar).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }));
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('cancels without submitting', async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    render(<NewLocationModal close={close} mutate={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(close).toHaveBeenCalledOnce();
+    expect(saveLocation).not.toHaveBeenCalled();
+  });
+});

--- a/src/stock-locations/add-locations-form.workspace.test.tsx
+++ b/src/stock-locations/add-locations-form.workspace.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { showModal, type DefaultWorkspaceProps } from '@openmrs/esm-framework';
+import { useStockTagLocations } from '../stock-lookups/stock-lookups.resource';
+import Workspace from './add-locations-form.workspace';
+
+vi.mock('../stock-lookups/stock-lookups.resource', () => ({ useStockTagLocations: vi.fn() }));
+
+const mutate = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(useStockTagLocations).mockReturnValue({ stockLocations: [], isLoading: false, error: undefined, mutate });
+  vi.mocked(showModal).mockImplementation((_name, _props, onClose) => () => onClose?.());
+});
+
+it('does not close the workspace during StrictMode setup or external unmount', () => {
+  const closeWorkspace = vi.fn();
+  const props: DefaultWorkspaceProps = {
+    closeWorkspace,
+    promptBeforeClosing: vi.fn(),
+    closeWorkspaceWithSavedChanges: vi.fn(),
+    setTitle: vi.fn(),
+  };
+  const { unmount } = render(
+    <React.StrictMode>
+      <Workspace {...props} />
+    </React.StrictMode>,
+  );
+  expect(closeWorkspace).not.toHaveBeenCalled();
+  unmount();
+  expect(closeWorkspace).not.toHaveBeenCalled();
+});
+
+it('closes the workspace once on modal dismissal and passes the bound refresh callback', () => {
+  const closeWorkspace = vi.fn();
+  const props: DefaultWorkspaceProps = {
+    closeWorkspace,
+    promptBeforeClosing: vi.fn(),
+    closeWorkspaceWithSavedChanges: vi.fn(),
+    setTitle: vi.fn(),
+  };
+  const { unmount } = render(<Workspace {...props} />);
+  expect(showModal).toHaveBeenCalledWith('stock-create-location-modal', { mutate }, expect.any(Function));
+  const onClose = vi.mocked(showModal).mock.calls[0][2];
+  onClose();
+  onClose();
+  unmount();
+  expect(closeWorkspace).toHaveBeenCalledOnce();
+});

--- a/src/stock-locations/add-locations-form.workspace.tsx
+++ b/src/stock-locations/add-locations-form.workspace.tsx
@@ -1,72 +1,23 @@
-import React, { useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
-import { showSnackbar } from '@openmrs/esm-framework';
-import { saveLocation } from './stock-locations-table.resource';
-import { type locationData, type LocationMutator } from '../stock-items/types';
-import { extractErrorMessagesFromResponse } from '../constants';
-import LocationAdministrationForm from './location-admin-form.component';
+import { useEffect, type FC } from 'react';
+import { showModal, type DefaultWorkspaceProps } from '@openmrs/esm-framework';
+import { useSWRConfig } from 'swr';
 
-interface LocationFormProps {
-  showModal: boolean;
-  onModalChange: (showModal: boolean) => void;
-  mutate: LocationMutator;
-}
-
-const NewLocationForm: React.FC<LocationFormProps> = ({ showModal, onModalChange, mutate }) => {
-  const { t } = useTranslation();
-  const headerTitle = t('addLocation', 'Create new Location');
-
-  const initialData: locationData = {
-    uuid: '',
-    name: '',
-    tags: [],
-  };
-
-  const handleCreateQuestion = useCallback(
-    (formData: locationData) => {
-      const { name, tags } = formData;
-
-      const locationbject = {
-        name,
-        tags,
-      };
-      saveLocation({ locationPayload: locationbject })
-        .then(() => {
-          showSnackbar({
-            title: t('locationCreatedTitle', 'Location created'),
-            kind: 'success',
-            isLowContrast: true,
-            subtitle: t('locationCreatedSuccessfully', 'Location {{locationName}} was created successfully.', {
-              locationName: name,
-            }),
-          });
-
-          mutate();
-          onModalChange(false);
-        })
-        .catch((error) => {
-          const errorMessages = extractErrorMessagesFromResponse(error);
-          showSnackbar({
-            title: t('errorCreatingForm', 'Error creating location'),
-            kind: 'error',
-            isLowContrast: true,
-            subtitle: errorMessages.join(', '),
-          });
-          onModalChange(false);
-        });
-      onModalChange(false);
-    },
-    [onModalChange, mutate, t],
-  );
-
-  return (
-    <LocationAdministrationForm
-      onModalChange={onModalChange}
-      showModal={showModal}
-      handleCreateQuestion={handleCreateQuestion}
-      headerTitle={headerTitle}
-      initialData={initialData}
-    />
-  );
+const NewLocationWorkspace: FC<DefaultWorkspaceProps> = ({ closeWorkspace }) => {
+  const { mutate } = useSWRConfig();
+  useEffect(() => {
+    let closed = false;
+    const dispose = showModal('stock-create-location-modal', { mutate }, () => {
+      closed = true;
+      closeWorkspace();
+    });
+    return () => {
+      if (!closed) {
+        closed = true;
+        dispose();
+      }
+    };
+  }, [closeWorkspace, mutate]);
+  return null;
 };
-export default NewLocationForm;
+
+export default NewLocationWorkspace;

--- a/src/stock-locations/add-locations-form.workspace.tsx
+++ b/src/stock-locations/add-locations-form.workspace.tsx
@@ -1,12 +1,15 @@
 import { useEffect, type FC } from 'react';
 import { showModal, type DefaultWorkspaceProps } from '@openmrs/esm-framework';
-import { useSWRConfig } from 'swr';
+import { useStockTagLocations } from '../stock-lookups/stock-lookups.resource';
 
 const NewLocationWorkspace: FC<DefaultWorkspaceProps> = ({ closeWorkspace }) => {
-  const { mutate } = useSWRConfig();
+  const { mutate } = useStockTagLocations();
   useEffect(() => {
     let closed = false;
     const dispose = showModal('stock-create-location-modal', { mutate }, () => {
+      if (closed) {
+        return;
+      }
       closed = true;
       closeWorkspace();
     });

--- a/src/stock-locations/location-admin-form.component.tsx
+++ b/src/stock-locations/location-admin-form.component.tsx
@@ -4,7 +4,6 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Button,
-  ComposedModal,
   FilterableMultiSelect,
   FormGroup,
   InlineNotification,
@@ -25,8 +24,7 @@ const LocationAdministrationSchema = z.object({
 });
 
 interface LocationAdministrationFormProps {
-  showModal: boolean;
-  onModalChange: (showModal: boolean) => void;
+  close: () => void;
   handleCreateQuestion?: (formData: locationData) => void;
   handleDeleteBedTag?: () => void;
   headerTitle: string;
@@ -38,8 +36,7 @@ interface ErrorType {
 }
 
 const LocationAdministrationForm: React.FC<LocationAdministrationFormProps> = ({
-  showModal,
-  onModalChange,
+  close,
   handleCreateQuestion,
   headerTitle,
   initialData,
@@ -87,10 +84,10 @@ const LocationAdministrationForm: React.FC<LocationAdministrationFormProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside size={'md'}>
-      <ModalHeader title={headerTitle} />
-      <form onSubmit={handleSubmit(onSubmit, onError)}>
-        <ModalBody hasScrollingContent>
+    <>
+      <ModalHeader closeModal={close} title={headerTitle} />
+      <ModalBody hasScrollingContent>
+        <form id="stock-location-form" onSubmit={handleSubmit(onSubmit, onError)}>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller
@@ -149,17 +146,17 @@ const LocationAdministrationForm: React.FC<LocationAdministrationFormProps> = ({
               />
             )}
           </Stack>
-        </ModalBody>
-        <ModalFooter>
-          <Button onClick={() => onModalChange(false)} kind="secondary">
-            {getCoreTranslation('cancel')}
-          </Button>
-          <Button disabled={!isDirty} type="submit">
-            <span>{t('save', 'Save')}</span>
-          </Button>
-        </ModalFooter>
-      </form>
-    </ComposedModal>
+        </form>
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={close} kind="secondary">
+          {getCoreTranslation('cancel')}
+        </Button>
+        <Button disabled={!isDirty} type="submit" form="stock-location-form">
+          <span>{t('save', 'Save')}</span>
+        </Button>
+      </ModalFooter>
+    </>
   );
 };
 

--- a/src/stock-locations/stock-locations-table.component.tsx
+++ b/src/stock-locations/stock-locations-table.component.tsx
@@ -9,9 +9,7 @@ import {
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { useSWRConfig } from 'swr';
-import { restBaseUrl, showModal } from '@openmrs/esm-framework';
-import { handleMutate } from '../utils';
+import { showModal } from '@openmrs/esm-framework';
 import { ResourceRepresentation } from '../core/api/api';
 import { useStockLocationPages } from './stock-locations-table.resource';
 import DataList from '../core/components/table/table.component';
@@ -23,16 +21,15 @@ interface StockLocationsTableProps {
 
 const StockLocationsItems: React.FC<StockLocationsTableProps> = () => {
   const { t } = useTranslation();
-  const { mutate } = useSWRConfig();
   const disposeModal = useRef<ReturnType<typeof showModal>>();
   useEffect(() => () => disposeModal.current?.(), []);
 
-  const { tableHeaders, tableRows, items, isLoading } = useStockLocationPages({
+  const { tableHeaders, tableRows, items, isLoading, mutate } = useStockLocationPages({
     v: ResourceRepresentation.Full,
   });
 
   const handleRefresh = () => {
-    handleMutate(`${restBaseUrl}/Location?_summary=data`);
+    mutate();
   };
 
   if (isLoading) {

--- a/src/stock-locations/stock-locations-table.component.tsx
+++ b/src/stock-locations/stock-locations-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   Button,
   DataTableSkeleton,
@@ -10,12 +10,11 @@ import {
 import { Add } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
-import { restBaseUrl } from '@openmrs/esm-framework';
+import { restBaseUrl, showModal } from '@openmrs/esm-framework';
 import { handleMutate } from '../utils';
 import { ResourceRepresentation } from '../core/api/api';
 import { useStockLocationPages } from './stock-locations-table.resource';
 import DataList from '../core/components/table/table.component';
-import NewLocationForm from './add-locations-form.workspace';
 import styles from '../stock-items/stock-items-table.scss';
 
 interface StockLocationsTableProps {
@@ -25,7 +24,8 @@ interface StockLocationsTableProps {
 const StockLocationsItems: React.FC<StockLocationsTableProps> = () => {
   const { t } = useTranslation();
   const { mutate } = useSWRConfig();
-  const [showLocationModal, setAddLocationModal] = useState(false);
+  const disposeModal = useRef<ReturnType<typeof showModal>>();
+  useEffect(() => () => disposeModal.current?.(), []);
 
   const { tableHeaders, tableRows, items, isLoading } = useStockLocationPages({
     v: ResourceRepresentation.Full,
@@ -50,13 +50,13 @@ const StockLocationsItems: React.FC<StockLocationsTableProps> = () => {
                 {t('refresh', 'Refresh')}
               </TableToolbarAction>
             </TableToolbarMenu>
-            {showLocationModal ? (
-              <NewLocationForm onModalChange={setAddLocationModal} showModal={showLocationModal} mutate={mutate} />
-            ) : null}
             <Button
               kind="ghost"
               renderIcon={(props) => <Add size={16} {...props} />}
-              onClick={() => setAddLocationModal(true)}
+              onClick={() => {
+                disposeModal.current?.();
+                disposeModal.current = showModal('stock-create-location-modal', { mutate });
+              }}
             >
               {t('createLocation', 'Create Location')}
             </Button>

--- a/src/stock-locations/stock-locations-table.resource.test.ts
+++ b/src/stock-locations/stock-locations-table.resource.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+import { useFhirFetchAll } from '@openmrs/esm-framework';
+import { useStockLocationPages } from './stock-locations-table.resource';
+
+it('exposes the FHIR list mutator through the location pagination hook', async () => {
+  const mutate = vi.fn();
+  vi.mocked(useFhirFetchAll).mockReturnValue({
+    data: [],
+    error: undefined,
+    isLoading: false,
+    mutate,
+    totalCount: 0,
+    hasMore: false,
+    loadMore: vi.fn(),
+    isValidating: false,
+    nextUri: null,
+  });
+  const { result } = renderHook(() => useStockLocationPages({}));
+  expect(useFhirFetchAll).toHaveBeenCalledWith(expect.stringContaining('/Location?_summary=data&_tag='));
+  await result.current.mutate();
+  expect(mutate).toHaveBeenCalledOnce();
+});

--- a/src/stock-locations/stock-locations-table.resource.ts
+++ b/src/stock-locations/stock-locations-table.resource.ts
@@ -6,7 +6,7 @@ import { type StockOperationFilter } from '../stock-operations/stock-operations.
 import { useStockTagLocations } from '../stock-lookups/stock-lookups.resource';
 
 export function useStockLocationPages(filter: StockOperationFilter) {
-  const { stockLocations, error, isLoading } = useStockTagLocations();
+  const { stockLocations, error, isLoading, mutate } = useStockTagLocations();
 
   const pageSizes = [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(10);
@@ -57,6 +57,7 @@ export function useStockLocationPages(filter: StockOperationFilter) {
   }, [stockLocations]);
   return {
     items: stockLocations,
+    mutate,
     currentPage,
     currentPageSize,
     paginatedQueueEntries,

--- a/src/stock-lookups/stock-lookups.resource.ts
+++ b/src/stock-lookups/stock-lookups.resource.ts
@@ -55,10 +55,11 @@ export function useStockLocations(filter: LocationFilterCriteria) {
 */
 export function useStockTagLocations() {
   const apiUrl = `${fhirBaseUrl}/Location?_summary=data&_tag=main store,main pharmacy,dispensary `;
-  const { data, error, isLoading } = useFhirFetchAll<fhir.Location>(apiUrl);
+  const { data, error, isLoading, mutate } = useFhirFetchAll<fhir.Location>(apiUrl);
 
   return {
     stockLocations: uniqBy(data, 'id') ?? [],
+    mutate,
     isLoading,
     error,
   };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This moves stock location creation to a framework modal while keeping the existing workspace registration working for callers that still use it. The Save button is explicitly linked to the form now that the modal footer sits outside it.

Successful saves and the Refresh action now revalidate the stock-location list through its bound mutate callback. The modal is also disposed when the table or workspace unmounts.

## Screenshots

## Related Issue

## Other
